### PR TITLE
**Package Dependency Fixes:**

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Your PR will be reviewed by your lead, and once approved, it will be merged into
 
 2. **Install required dependencies**
 ```bash
-rosdep install --from-paths src/athena-code -y --ignore-src
+rosdep install --from-paths src y --ignore-src
 ```
 
 3. **Build the workspace**

--- a/src/subsystems/navigation/athena_map/package.xml
+++ b/src/subsystems/navigation/athena_map/package.xml
@@ -12,7 +12,7 @@
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
-  <depend>opencv4</depend>
+  <depend>libopencv-dev</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/subsystems/navigation/athena_planner/package.xml
+++ b/src/subsystems/navigation/athena_planner/package.xml
@@ -18,7 +18,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 
-  <exec_depend>nav2_planner_server</exec_depend>
+  <exec_depend>nav2_planner</exec_depend>
   <exec_depend>nav2_costmap_2d</exec_depend>
   <exec_depend>nav2_lifecycle_manager</exec_depend>
   <exec_depend>nav2_smac_planner</exec_depend>

--- a/src/subsystems/navigation/localizer/CMakeLists.txt
+++ b/src/subsystems/navigation/localizer/CMakeLists.txt
@@ -6,6 +6,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+
+# Add ROS2 GTSAM path to CMAKE_PREFIX_PATH
+list(APPEND CMAKE_PREFIX_PATH "/opt/ros/humble")
+
 find_package(GTSAM REQUIRED)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
 find_package(GeographicLib REQUIRED)

--- a/src/subsystems/navigation/obstacle_detection/package.xml
+++ b/src/subsystems/navigation/obstacle_detection/package.xml
@@ -18,12 +18,11 @@
   <depend>tf2_sensor_msgs</depend>
   <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
-  <depend>zed_interfaces</depend>
   <depend>zed_msgs</depend>
 
   <!-- System libs (via rosdep) -->
-  <build_depend>libpcl-dev</build_depend>
-  <exec_depend>libpcl-dev</exec_depend>
+  <build_depend>libpcl-all-dev</build_depend>
+  <exec_depend>libpcl-all-dev</exec_depend>
 
   <!-- Eigen (portable find_package support) -->
   <build_depend>eigen3_cmake_module</build_depend>


### PR DESCRIPTION
- athena_map: Fix OpenCV dependency (opencv4 → libopencv-dev)
- athena_planner: Fix Nav2 planner dependency (nav2_planner_server → nav2_planner)
- obstacle_detection: Remove unused zed_interfaces dependency, fix PCL dependency (libpcl-dev → libpcl-all-dev)
- localizer: Add CMAKE_PREFIX_PATH for ROS2 GTSAM installation