### PR TITLE
Refactor subsystems to single use_sim launch argument

### DIFF
--- a/src/description/config/odrive.ros2_control.xacro
+++ b/src/description/config/odrive.ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="odrive_ros2_control" params="name">
+  <xacro:macro name="odrive_ros2_control" params="name can_interface">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>odrive_ros2_control_plugin/ODriveHardwareInterface</plugin>
-        <param name="can">can0</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
        <!-- 

--- a/src/description/ros2_control/arm/arm.mock.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.mock.ros2_control.xacro
@@ -17,64 +17,64 @@
             <joint name="base_yaw">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="shoulder_pitch">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="elbow_pitch">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="wrist_pitch">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="wrist_roll">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="gripper_claw">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                    <param name="initial_value">-0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="actuator">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                    <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             </ros2_control>

--- a/src/description/ros2_control/arm/arm.rmd.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.rmd.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="rmd_ros2_control" params="name">
+  <xacro:macro name="rmd_ros2_control" params="name can_interface">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>rmd_ros2_control/RMDHardwareInterface</plugin>
         <param name="update_rate">2</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="shoulder_pitch">

--- a/src/description/ros2_control/arm/arm.servo.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.servo.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="servo_ros2_control" params="name">
+    <xacro:macro name="servo_ros2_control" params="name can_interface">
         <ros2_control name="${name}" type="system">
             <hardware>
                 <plugin>servo_ros2_control/SERVOHardwareInterface</plugin>
                 <param name="update_rate">1</param> <!-- Hz -->
                 <param name="logger_rate">5</param> <!-- Hz -->
                 <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-                <param name="can_interface">can0</param>
+                <param name="can_interface">${can_interface}</param>
                 <param name="can_id">0x80</param>
             </hardware>
 

--- a/src/description/ros2_control/arm/arm.smc.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.smc.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="smc_ros2_control" params="name">
+  <xacro:macro name="smc_ros2_control" params="name can_interface">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>smc_ros2_control/SMCHardwareInterface</plugin>
         <param name="update_rate">2</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="base_yaw">

--- a/src/description/ros2_control/arm/arm.talon.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.talon.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="talon_ros2_control" params="name">
+  <xacro:macro name="talon_ros2_control" params="name can_interface">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>talon_ros2_control/TALONHardwareInterface</plugin>
         <param name="update_rate">10</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="gripper_claw">

--- a/src/description/ros2_control/drive/drive.killswitch.ros2_control.xacro
+++ b/src/description/ros2_control/drive/drive.killswitch.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="killswitch_ros2_control" params="name can_interface:=can0">
+  <xacro:macro name="killswitch_ros2_control" params="name can_interface">
 
     <ros2_control name="${name}" type="system">
       <hardware>

--- a/src/description/ros2_control/drive/drive.odrive.ros2_control.xacro
+++ b/src/description/ros2_control/drive/drive.odrive.ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="odrive_ros2_control" params="name">
+  <xacro:macro name="odrive_ros2_control" params="name can_interface">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>odrive_ros2_control_plugin/ODriveHardwareInterface</plugin>
-        <param name="can">can0</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="steer_bl_joint">

--- a/src/description/ros2_control/drive/drive.rmd.ros2_control.xacro
+++ b/src/description/ros2_control/drive/drive.rmd.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="rmd_ros2_control" params="name">
+  <xacro:macro name="rmd_ros2_control" params="name can_interface">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>rmd_ros2_control/RMDHardwareInterface</plugin>
         <param name="update_rate">30</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="propulsion_fl_joint">

--- a/src/description/ros2_control/science/science.laser.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.laser.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="laser_ros2_control" params="name can_interface:=can0">
+    <xacro:macro name="laser_ros2_control" params="name can_interface">
 
         <ros2_control name="${name}" type="system">
 

--- a/src/description/ros2_control/science/science.mock.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.mock.ros2_control.xacro
@@ -14,12 +14,13 @@
                 <param name="position_state_following_offset">0.0</param>
             </hardware>
 
-
             <joint name="stepper_motor_a">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
                 <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="stepper_motor_b">
@@ -27,6 +28,8 @@
                 <command_interface name="velocity"/>
                 <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="talon_lift">
@@ -36,10 +39,10 @@
                 <param name="max">1</param>
                 </command_interface>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="talon_scoop">
@@ -49,22 +52,26 @@
                 <param name="max">1</param>
                 </command_interface>
                 <command_interface name="velocity"/>
-                <state_interface name="position">
-                <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="servo_scoop_a">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
                 <state_interface name="position"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="servo_scoop_b">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
                 <state_interface name="position"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="auger">
@@ -72,18 +79,24 @@
                 <command_interface name="velocity"/>
                 <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="cap">
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
                 <state_interface name="position"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             <joint name="auger_spinner">
                 <command_interface name="velocity"/>
                 <state_interface name="position"/>
                 <state_interface name="velocity"/>
+                <state_interface name="motor_temperature"/>
+                <state_interface name="torque_current"/>
             </joint>
 
             </ros2_control>

--- a/src/description/ros2_control/science/science.servo.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.servo.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="servo_ros2_control" params="name">
+    <xacro:macro name="servo_ros2_control" params="name can_interface">
         <ros2_control name="${name}" type="system">
             <hardware>
                 <plugin>servo_ros2_control/SERVOHardwareInterface</plugin>
                 <param name="update_rate">20</param> <!-- Hz -->
                 <param name="logger_rate">5</param> <!-- Hz -->
                 <param name="logger_state">1</param> <!-- 0 for off, 1 for on -->
-                <param name="can_interface">can0</param>
+                <param name="can_interface">${can_interface}</param>
                 <param name="can_id">0x80</param>
             </hardware>
 

--- a/src/description/ros2_control/science/science.talon.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.talon.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="talon_ros2_control" params="name">
+  <xacro:macro name="talon_ros2_control" params="name can_interface">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>talon_ros2_control/TALONHardwareInterface</plugin>
         <param name="update_rate">10</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="talon_auger">

--- a/src/description/urdf/athena_arm.urdf.xacro
+++ b/src/description/urdf/athena_arm.urdf.xacro
@@ -5,9 +5,10 @@
   <xacro:arg name="prefix" default=""/>
   <xacro:arg name="use_mock_hardware" default="false"/>
   <xacro:arg name="mock_sensor_commands" default="false"/>
-  <xacro:arg name="sim_gazebo_classic" default="true"/>
-  <xacro:arg name="sim_gazebo" default="true"/>
-  <xacro:arg name="simulation_controllers" default=""/>
+  <xacro:arg name="use_sim" default="false"/>
+
+  <!-- Derive CAN interface name from use_sim -->
+  <xacro:property name="can_interface" value="${'vcan0' if '$(arg use_sim)' == 'true' else 'can0'}"/>
 
   <!-- Macro Imports -->
   <!-- Import athena_arm macro -->
@@ -44,7 +45,7 @@
     <xacro:mock_ros2_control name="mock"/>
   </xacro:if>
   <xacro:unless value="$(arg use_mock_hardware)"> <!-- HARDWARE -->
-    <xacro:smc_ros2_control name="smc"/>
+    <xacro:smc_ros2_control name="smc" can_interface="${can_interface}"/>
     <ros2_control name="talon_mock" type="system">
       <hardware>
         <plugin>mock_components/GenericSystem</plugin>
@@ -58,9 +59,9 @@
         <state_interface name="velocity"/>
       </joint>
     </ros2_control>
-    <xacro:rmd_ros2_control name="rmd"/>
-    <xacro:servo_ros2_control name="servo"/>
-    <!-- <xacro:odrive_ros2_control name="odrive"/> -->
+    <xacro:rmd_ros2_control name="rmd" can_interface="${can_interface}"/>
+    <xacro:servo_ros2_control name="servo" can_interface="${can_interface}"/>
+    <!-- <xacro:odrive_ros2_control name="odrive" can_interface="${can_interface}"/> -->
   </xacro:unless>
 
 </robot>

--- a/src/description/urdf/athena_arm.urdf.xacro
+++ b/src/description/urdf/athena_arm.urdf.xacro
@@ -15,7 +15,7 @@
   <xacro:include filename="$(find description)/urdf/athena_arm_description.urdf.xacro"/>
 
   <!-- Import mock ros2_control description -->
-  <xacro:include filename="$(find description)/config/mock.ros2_control.xacro" />
+  <xacro:include filename="$(find description)/ros2_control/arm/arm.mock.ros2_control.xacro" />
 
   <!-- Import smc ros2_control description -->
   <xacro:include filename="$(find description)/ros2_control/arm/arm.smc.ros2_control.xacro" />

--- a/src/description/urdf/athena_drive.urdf.xacro
+++ b/src/description/urdf/athena_drive.urdf.xacro
@@ -6,8 +6,12 @@
 
   <xacro:arg name="use_mock_hardware" default="false"/>
   <xacro:arg name="mock_sensor_commands" default="false"/>
-  <xacro:arg name="sim_gazebo" default="true"/>
+  <xacro:arg name="sim_gazebo" default="false"/>
   <xacro:arg name="simulation_controllers" default=""/>
+  <xacro:arg name="use_sim" default="false"/>
+
+  <!-- Derive CAN interface name from use_sim -->
+  <xacro:property name="can_interface" value="${'vcan0' if '$(arg use_sim)' == 'true' else 'can0'}"/>
 
 
   <xacro:include filename="$(find description)/urdf/athena_drive/athena_drive_macro.xacro"/>
@@ -70,14 +74,14 @@
     simulation_controllers="$(arg simulation_controllers)"/>
   </xacro:if>
   <xacro:unless value="$(arg use_mock_hardware)">
-    <xacro:odrive_ros2_control name="odrive"/>
-    <xacro:rmd_ros2_control name="rmd"/>
+    <xacro:odrive_ros2_control name="odrive" can_interface="${can_interface}"/>
+    <xacro:rmd_ros2_control name="rmd" can_interface="${can_interface}"/>
 
     <!-- LED status indicator (GPIO-based) -->
     <xacro:led_ros2_control name="status_led" gpio_pin="25"/>
 
     <!-- Killswitch (CAN-based) -->
-    <xacro:killswitch_ros2_control name="drive_killswitch"/>
+    <xacro:killswitch_ros2_control name="drive_killswitch" can_interface="${can_interface}"/>
   </xacro:unless>
 
   

--- a/src/description/urdf/athena_drive/athena_drive_macro.ros2_control.xacro
+++ b/src/description/urdf/athena_drive/athena_drive_macro.ros2_control.xacro
@@ -31,10 +31,10 @@
       <param name="min">-1.0471975512</param>
       <param name="max">1.0471975512</param>
     </command_interface>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
   
   <joint name="${prefix}suspension_front_right_joint">
@@ -42,10 +42,10 @@
       <param name="min">-1.0471975512</param>
       <param name="max">1.0471975512</param>
     </command_interface>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
   
   <joint name="${prefix}steer_fl_joint">
@@ -53,10 +53,10 @@
       <param name="min">-0.78539816339</param>
       <param name="max">0.78539816339</param>
     </command_interface>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
   
   <joint name="${prefix}steer_fr_joint">
@@ -64,10 +64,10 @@
       <param name="min">-0.78539816339</param>
       <param name="max">0.78539816339</param>
     </command_interface>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
   
   <joint name="${prefix}steer_br_joint">
@@ -75,10 +75,10 @@
       <param name="min">0.78539816339</param>
       <param name="max">-0.78539816339</param>
     </command_interface>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
   
   <joint name="${prefix}steer_bl_joint">
@@ -86,45 +86,45 @@
       <param name="min">-0.78539816339</param>
       <param name="max">0.78539816339</param>
     </command_interface>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
   
 
   <joint name="${prefix}propulsion_fl_joint">
     <command_interface name="velocity"/>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
 
   <joint name="${prefix}propulsion_fr_joint">
     <command_interface name="velocity"/>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
   
 
   <joint name="${prefix}propulsion_br_joint">
     <command_interface name="velocity"/>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
 
 
   <joint name="${prefix}propulsion_bl_joint">
     <command_interface name="velocity"/>
-    <state_interface name="position">
-      <param name="initial_value">0.0</param>
-    </state_interface>
+    <state_interface name="position"/>
     <state_interface name="velocity"/>
+    <state_interface name="motor_temperature"/>
+    <state_interface name="torque_current"/>
   </joint>
 </ros2_control>
 

--- a/src/description/urdf/athena_science.urdf.xacro
+++ b/src/description/urdf/athena_science.urdf.xacro
@@ -3,6 +3,10 @@
 
   <xacro:arg name="use_mock_hardware" default="false"/>
   <xacro:arg name="mock_sensor_commands" default="false"/>
+  <xacro:arg name="use_sim" default="false"/>
+
+  <!-- Derive CAN interface name from use_sim -->
+  <xacro:property name="can_interface" value="${'vcan0' if '$(arg use_sim)' == 'true' else 'can0'}"/>
 
   <xacro:include filename="$(find description)/ros2_control/science/science.mock.ros2_control.xacro"/>
 
@@ -28,13 +32,13 @@
     <xacro:stepper_ros2_control name="stepper"/>
 
     <!-- Import servo ros2_control description -->
-    <xacro:servo_ros2_control name="servo"/>
+    <xacro:servo_ros2_control name="servo" can_interface="${can_interface}"/>
 
     <!-- Import talon ros2_control description -->
-    <xacro:talon_ros2_control name="talon"/>
+    <xacro:talon_ros2_control name="talon" can_interface="${can_interface}"/>
 
     <!-- Import laser ros2_control description (CAN-based) -->
-    <xacro:laser_ros2_control name="spectrometry_laser"/>
+    <xacro:laser_ros2_control name="spectrometry_laser" can_interface="${can_interface}"/>
   </xacro:unless>
 
 </robot>

--- a/src/hardware_interfaces/ros_odrive/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/src/hardware_interfaces/ros_odrive/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -116,7 +116,7 @@ CallbackReturn ODriveHardwareInterface::on_init(const hardware_interface::Hardwa
         return CallbackReturn::ERROR;
     }
 
-    can_intf_name_ = info_.hardware_parameters["can"];
+    can_intf_name_ = info_.hardware_parameters["can_interface"];
 
     for (auto& joint : info_.joints) {
         axes_.emplace_back(&can_intf_, std::stoi(joint.parameters.at("node_id")), std::stoi(joint.parameters.at("gear_ratio")));

--- a/src/infrastructure/umdloop_can/umdloop_can/can_node.py
+++ b/src/infrastructure/umdloop_can/umdloop_can/can_node.py
@@ -7,10 +7,11 @@ class CANNode(Node):
     def __init__(self):
         super().__init__('can_node')
 
-        # Publisher for incoming CAN data
+        self.declare_parameter('can_interface', 'can0')
+        can_channel = self.get_parameter('can_interface').get_parameter_value().string_value
+
         self.publisher_ = self.create_publisher(CANA, 'can_rx', 10)
 
-        # Subscriber for outgoing CAN data
         self.subscription = self.create_subscription(
             CANA,
             'can_tx',
@@ -18,9 +19,9 @@ class CANNode(Node):
             10
         )
 
-        self.can_interface = CANInterface(callback=self.can_rx_callback)
+        self.can_interface = CANInterface(callback=self.can_rx_callback, channel=can_channel)
         
-        self.get_logger().info('CAN Node Initialized')
+        self.get_logger().info(f'CAN Node Initialized on {can_channel}')
 
         # # Check for new CAN messages at 100Hz
         # self.timer = self.create_timer(0.01, self.check_can_messages)

--- a/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
+++ b/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
@@ -261,16 +261,20 @@ def launch_setup(context, *args, **kwargs):
         arguments=["motor_status_broadcaster", "-c", "/controller_manager"],
     )
 
-    robot_controller_names = [robot_controller]
-    robot_controller_spawners = []
-    for controller in robot_controller_names:
-        robot_controller_spawners += [
-            Node(
-                package="controller_manager",
-                executable="spawner",
-                arguments=[controller, "-c", "/controller_manager"],
-            )
-        ]
+    # Manual joint-by-joint controller: active only when use_sim is false
+    robot_controller_spawner_active = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[robot_controller, "-c", "/controller_manager"],
+        condition=UnlessCondition(use_sim),
+    )
+    robot_controller_spawner_inactive = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[robot_controller, "-c", "/controller_manager", "--inactive"],
+        condition=IfCondition(use_sim),
+    )
+    robot_controller_spawners = [robot_controller_spawner_active]
 
     # JTC: active when use_sim=true, inactive otherwise
     jtc_spawner_active = Node(
@@ -288,6 +292,7 @@ def launch_setup(context, *args, **kwargs):
 
     inactive_robot_controller_names = ["manual_arm_cylindrical_controller", "arm_velocity_controller"]
     inactive_robot_controller_spawners = []
+    inactive_robot_controller_spawners += [robot_controller_spawner_inactive]
     for controller in inactive_robot_controller_names:
         inactive_robot_controller_spawners += [
             Node(
@@ -299,9 +304,23 @@ def launch_setup(context, *args, **kwargs):
     # Append JTC spawners (only one will run based on use_sim condition)
     inactive_robot_controller_spawners += [jtc_spawner_active, jtc_spawner_inactive]
 
-    controller_switcher_node = RegisterEventHandler(
+    controller_switcher_node_active = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=inactive_robot_controller_spawners[-1],
+            target_action=jtc_spawner_active,
+            on_exit=[TimerAction(
+                period=3.0,
+                actions=[Node(
+                    package="arm_bringup",
+                    executable="controller_switcher.py",
+                    name="controller_switcher",
+                    output="screen"
+                )]
+            )],
+        )
+    )
+    controller_switcher_node_inactive = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=jtc_spawner_inactive,
             on_exit=[TimerAction(
                 period=3.0,
                 actions=[Node(
@@ -373,20 +392,23 @@ def launch_setup(context, *args, **kwargs):
     # -- CAN Setup (driven by use_sim) --
     can_setup_sim = ExecuteProcess(
         cmd=['bash', '-c',
-             'sudo modprobe vcan && '
-             'sudo ip link add dev vcan0 type vcan && '
-             'sudo ip link set up vcan0'],
+             'sudo modprobe vcan || true; '
+             'sudo ip link add dev vcan0 type vcan 2>/dev/null || true; '
+             'sudo ip link set up vcan0 || true'],
         condition=IfCondition(use_sim),
         output='screen',
     )
     can_setup_real = ExecuteProcess(
         cmd=['bash', '-c',
              'sudo killall slcand 2>/dev/null; sleep 1; '
-             'if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
-             'elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
-             'else echo "No CANable device found"; exit 1; fi && '
-             'sudo ip link set can0 up && '
-             'sudo ip link set can0 txqueuelen 1000'],
+             'if ip link show can0 >/dev/null 2>&1; then '
+             '  sudo ip link set can0 up && sudo ip link set can0 txqueuelen 1000; '
+             'else '
+             '  if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
+             '  elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
+             '  else echo "No CANable device found and can0 does not exist"; exit 1; fi && '
+             '  sudo ip link set can0 up && sudo ip link set can0 txqueuelen 1000; '
+             'fi'],
         condition=UnlessCondition(use_sim),
         output='screen',
     )
@@ -395,11 +417,10 @@ def launch_setup(context, *args, **kwargs):
     can_teardown = RegisterEventHandler(
         event_handler=OnShutdown(
             on_shutdown=[ExecuteProcess(
-                cmd=['bash', '-c', PythonExpression([
-                    "'sudo ip link set down vcan0 2>/dev/null || true' if '",
-                    use_sim,
-                    "' == 'true' else 'sudo ip link set down can0 2>/dev/null || true'"
-                ])],
+                cmd=['bash', '-c',
+                     'sudo -n ip link set down vcan0 2>/dev/null || true; '
+                     'sudo -n ip link set down can0 2>/dev/null || true; '
+                     'sudo -n killall slcand 2>/dev/null || true'],
                 output='screen',
             )],
         ),
@@ -423,7 +444,8 @@ def launch_setup(context, *args, **kwargs):
         delay_joint_state_broadcaster_spawner_after_ros2_control_node,
         delay_motor_status_broadcaster_after_joint_state_broadcaster,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        controller_switcher_node,
+        controller_switcher_node_active,
+        controller_switcher_node_inactive,
     ] + delay_robot_controller_spawners_after_joint_state_broadcaster_spawner \
       + delay_inactive_robot_controller_spawners_after_joint_state_broadcaster_spawner
 

--- a/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
+++ b/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
@@ -1,8 +1,8 @@
 from launch import LaunchDescription, LaunchContext
-from launch.actions import RegisterEventHandler, DeclareLaunchArgument, TimerAction, OpaqueFunction
-from launch.conditions import IfCondition
-from launch.event_handlers import OnProcessExit, OnProcessStart
-from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
+from launch.actions import RegisterEventHandler, DeclareLaunchArgument, TimerAction, OpaqueFunction, ExecuteProcess
+from launch.conditions import IfCondition, UnlessCondition
+from launch.event_handlers import OnProcessExit, OnProcessStart, OnShutdown
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration, PythonExpression
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -28,6 +28,14 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_sim",
+            default_value="false",
+            description="Simulation mode: enables mock hardware, virtual CAN (vcan0), "
+                        "MoveIt, and joint trajectory controller on startup.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_rviz",
             default_value="true",
             description="Start RViz2 automatically with this launch file.",
         )
@@ -90,15 +98,16 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "use_mock_hardware",
             default_value="false",
-            description="Start robot with mock hardware mirroring command to its states.",
+            description="Start robot with mock hardware mirroring command to its states. "
+                        "Automatically true when use_sim is true.",
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "mock_sensor_commands",
             default_value="false",
-            description="Enable mock command interfaces for sensors used for simple simulations. \
-            Used only if 'use_mock_hardware' parameter is true.",
+            description="Enable mock command interfaces for sensors used for simple simulations. "
+                        "Automatically true when use_sim is true.",
         )
     )
     declared_arguments.append(
@@ -116,6 +125,7 @@ def generate_launch_description():
 def launch_setup(context, *args, **kwargs):
     mode = LaunchConfiguration("mode").perform(context)
     use_sim = LaunchConfiguration("use_sim")
+    use_rviz = LaunchConfiguration("use_rviz")
     runtime_config_package = LaunchConfiguration("runtime_config_package")
     controllers_file = LaunchConfiguration("controllers_file")
     description_package = LaunchConfiguration("description_package")
@@ -127,6 +137,13 @@ def launch_setup(context, *args, **kwargs):
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
 
+    # When use_sim is true, force mock hardware and mock sensor commands on
+    use_mock_hardware_effective = PythonExpression([
+        "'true' if '", use_sim, "' == 'true' else '", use_mock_hardware, "'"
+    ])
+    mock_sensor_commands_effective = PythonExpression([
+        "'true' if '", use_sim, "' == 'true' else '", mock_sensor_commands, "'"
+    ])
     robot_description_path = PathJoinSubstitution(
         [FindPackageShare("description"), "urdf", "athena_arm.urdf.xacro"]
     )
@@ -163,10 +180,13 @@ def launch_setup(context, *args, **kwargs):
             prefix,
             " ",
             "use_mock_hardware:=",
-            use_mock_hardware,
+            use_mock_hardware_effective,
             " ",
             "mock_sensor_commands:=",
-            mock_sensor_commands,
+            mock_sensor_commands_effective,
+            " ",
+            "use_sim:=",
+            use_sim,
             " ",
         ]
     )
@@ -179,7 +199,7 @@ def launch_setup(context, *args, **kwargs):
         .robot_description_kinematics(file_path=robot_kinematics_path.perform(LaunchContext()))
         .trajectory_execution(file_path=moveit_controllers_config_path.perform(LaunchContext()))
         .planning_scene_monitor(
-            publish_robot_description=True, publish_robot_description_semantic=True
+            publish_robot_description=False, publish_robot_description_semantic=True
         )
         .planning_pipelines(
             pipelines=["ompl", "pilz_industrial_motion_planner"],
@@ -219,7 +239,7 @@ def launch_setup(context, *args, **kwargs):
         name="rviz2",
         output="log",
         arguments=["-d", rviz_config_file],
-        condition=IfCondition(use_sim),
+        condition=IfCondition(use_rviz),
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
@@ -252,7 +272,21 @@ def launch_setup(context, *args, **kwargs):
             )
         ]
 
-    inactive_robot_controller_names = ["manual_arm_cylindrical_controller", "joint_trajectory_controller", "arm_velocity_controller"]
+    # JTC: active when use_sim=true, inactive otherwise
+    jtc_spawner_active = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_trajectory_controller", "-c", "/controller_manager"],
+        condition=IfCondition(use_sim),
+    )
+    jtc_spawner_inactive = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_trajectory_controller", "-c", "/controller_manager", "--inactive"],
+        condition=UnlessCondition(use_sim),
+    )
+
+    inactive_robot_controller_names = ["manual_arm_cylindrical_controller", "arm_velocity_controller"]
     inactive_robot_controller_spawners = []
     for controller in inactive_robot_controller_names:
         inactive_robot_controller_spawners += [
@@ -262,6 +296,8 @@ def launch_setup(context, *args, **kwargs):
                 arguments=[controller, "-c", "/controller_manager", "--inactive"],
             )
         ]
+    # Append JTC spawners (only one will run based on use_sim condition)
+    inactive_robot_controller_spawners += [jtc_spawner_active, jtc_spawner_inactive]
 
     controller_switcher_node = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -334,9 +370,56 @@ def launch_setup(context, *args, **kwargs):
             )
         ]
 
+    # -- CAN Setup (driven by use_sim) --
+    can_setup_sim = ExecuteProcess(
+        cmd=['bash', '-c',
+             'sudo modprobe vcan && '
+             'sudo ip link add dev vcan0 type vcan && '
+             'sudo ip link set up vcan0'],
+        condition=IfCondition(use_sim),
+        output='screen',
+    )
+    can_setup_real = ExecuteProcess(
+        cmd=['bash', '-c',
+             'sudo killall slcand 2>/dev/null; sleep 1; '
+             'if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
+             'elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
+             'else echo "No CANable device found"; exit 1; fi && '
+             'sudo ip link set can0 up && '
+             'sudo ip link set can0 txqueuelen 1000'],
+        condition=UnlessCondition(use_sim),
+        output='screen',
+    )
+
+    # -- CAN Teardown on Shutdown --
+    can_teardown = RegisterEventHandler(
+        event_handler=OnShutdown(
+            on_shutdown=[ExecuteProcess(
+                cmd=['bash', '-c', PythonExpression([
+                    "'sudo ip link set down vcan0 2>/dev/null || true' if '",
+                    use_sim,
+                    "' == 'true' else 'sudo ip link set down can0 2>/dev/null || true'"
+                ])],
+                output='screen',
+            )],
+        ),
+    )
+
+    move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=[moveit_config.to_dict()],
+        condition=IfCondition(use_sim),
+    )
+
     jetson_actions = [
+        can_setup_sim,
+        can_setup_real,
+        can_teardown,
         control_node,
         robot_state_pub_node,
+        move_group_node,
         delay_joint_state_broadcaster_spawner_after_ros2_control_node,
         delay_motor_status_broadcaster_after_joint_state_broadcaster,
         delay_rviz_after_joint_state_broadcaster_spawner,

--- a/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
+++ b/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
@@ -1,8 +1,8 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction, RegisterEventHandler, TimerAction
-from launch.conditions import IfCondition
-from launch.event_handlers import OnProcessExit, OnProcessStart
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument, OpaqueFunction, RegisterEventHandler, TimerAction, ExecuteProcess
+from launch.conditions import IfCondition, UnlessCondition
+from launch.event_handlers import OnProcessExit, OnProcessStart, OnShutdown
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -25,6 +25,13 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_sim",
+            default_value="false",
+            description="Simulation mode: enables mock hardware and virtual CAN (vcan0).",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_rviz",
             default_value="true",
             description="Start RViz2 automatically with this launch file.",
         )
@@ -93,15 +100,16 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "use_mock_hardware",
             default_value="false",
-            description="Start robot with mock hardware mirroring command to its states.",
+            description="Start robot with mock hardware mirroring command to its states. "
+                        "Automatically true when use_sim is true.",
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "mock_sensor_commands",
             default_value="false",
-            description="Enable mock command interfaces for sensors used for simple simulations. \
-            Used only if 'use_mock_hardware' parameter is true.",
+            description="Enable mock command interfaces for sensors used for simple simulations. "
+                        "Automatically true when use_sim is true.",
         )
     )
     declared_arguments.append(
@@ -119,6 +127,7 @@ def generate_launch_description():
 def launch_setup(context, *args, **kwargs):
     mode = LaunchConfiguration("mode").perform(context)
     use_sim = LaunchConfiguration("use_sim")
+    use_rviz = LaunchConfiguration("use_rviz")
     runtime_config_package = LaunchConfiguration("runtime_config_package")
     joystick_config_name = LaunchConfiguration("joystick_config")
     teleop_twist_config_name = LaunchConfiguration("teleop_twist_config")
@@ -131,6 +140,13 @@ def launch_setup(context, *args, **kwargs):
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
 
+    # When use_sim is true, force mock hardware and mock sensor commands on
+    use_mock_hardware_effective = PythonExpression([
+        "'true' if '", use_sim, "' == 'true' else '", use_mock_hardware, "'"
+    ])
+    mock_sensor_commands_effective = PythonExpression([
+        "'true' if '", use_sim, "' == 'true' else '", mock_sensor_commands, "'"
+    ])
     robot_description_path = PathJoinSubstitution(
         [FindPackageShare(description_package), "urdf", description_file]
     )
@@ -157,10 +173,13 @@ def launch_setup(context, *args, **kwargs):
             prefix,
             " ",
             "use_mock_hardware:=",
-            use_mock_hardware,
+            use_mock_hardware_effective,
             " ",
             "mock_sensor_commands:=",
-            mock_sensor_commands,
+            mock_sensor_commands_effective,
+            " ",
+            "use_sim:=",
+            use_sim,
             " ",
         ]
     )
@@ -215,7 +234,7 @@ def launch_setup(context, *args, **kwargs):
         name="rviz2",
         output="log",
         arguments=["-d", rviz_config_file],
-        condition=IfCondition(use_sim),
+        condition=IfCondition(use_rviz),
     )
 
     joint_state_broadcaster_spawner = Node(
@@ -350,6 +369,55 @@ def launch_setup(context, *args, **kwargs):
         ]
 
     jetson_actions = [
+        control_node,
+        robot_state_pub_node,
+        delay_joint_state_broadcaster_spawner_after_ros2_control_node,
+        delay_motor_status_broadcaster_after_joint_state_broadcaster,
+        delay_rviz_after_joint_state_broadcaster_spawner,
+        controller_switcher_node,
+    ] + delay_robot_controller_spawners_after_joint_state_broadcaster_spawner \
+      + delay_inactive_robot_controller_spawners_after_joint_state_broadcaster_spawner \
+      + delay_gpio_controller_spawners_after_joint_state_broadcaster_spawner
+
+    # -- CAN Setup (driven by use_sim) --
+    can_setup_sim = ExecuteProcess(
+        cmd=['bash', '-c',
+             'sudo modprobe vcan && '
+             'sudo ip link add dev vcan0 type vcan && '
+             'sudo ip link set up vcan0'],
+        condition=IfCondition(use_sim),
+        output='screen',
+    )
+    can_setup_real = ExecuteProcess(
+        cmd=['bash', '-c',
+             'sudo killall slcand 2>/dev/null; sleep 1; '
+             'if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
+             'elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
+             'else echo "No CANable device found"; exit 1; fi && '
+             'sudo ip link set can0 up && '
+             'sudo ip link set can0 txqueuelen 1000'],
+        condition=UnlessCondition(use_sim),
+        output='screen',
+    )
+
+    # -- CAN Teardown on Shutdown --
+    can_teardown = RegisterEventHandler(
+        event_handler=OnShutdown(
+            on_shutdown=[ExecuteProcess(
+                cmd=['bash', '-c', PythonExpression([
+                    "'sudo ip link set down vcan0 2>/dev/null || true' if '",
+                    use_sim,
+                    "' == 'true' else 'sudo ip link set down can0 2>/dev/null || true'"
+                ])],
+                output='screen',
+            )],
+        ),
+    )
+
+    jetson_actions = [
+        can_setup_sim,
+        can_setup_real,
+        can_teardown,
         control_node,
         robot_state_pub_node,
         delay_joint_state_broadcaster_spawner_after_ros2_control_node,

--- a/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
+++ b/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
@@ -382,20 +382,23 @@ def launch_setup(context, *args, **kwargs):
     # -- CAN Setup (driven by use_sim) --
     can_setup_sim = ExecuteProcess(
         cmd=['bash', '-c',
-             'sudo modprobe vcan && '
-             'sudo ip link add dev vcan0 type vcan && '
-             'sudo ip link set up vcan0'],
+             'sudo modprobe vcan || true; '
+             'sudo ip link add dev vcan0 type vcan 2>/dev/null || true; '
+             'sudo ip link set up vcan0 || true'],
         condition=IfCondition(use_sim),
         output='screen',
     )
     can_setup_real = ExecuteProcess(
         cmd=['bash', '-c',
              'sudo killall slcand 2>/dev/null; sleep 1; '
-             'if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
-             'elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
-             'else echo "No CANable device found"; exit 1; fi && '
-             'sudo ip link set can0 up && '
-             'sudo ip link set can0 txqueuelen 1000'],
+             'if ip link show can0 >/dev/null 2>&1; then '
+             '  sudo ip link set can0 up && sudo ip link set can0 txqueuelen 1000; '
+             'else '
+             '  if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
+             '  elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
+             '  else echo "No CANable device found and can0 does not exist"; exit 1; fi && '
+             '  sudo ip link set can0 up && sudo ip link set can0 txqueuelen 1000; '
+             'fi'],
         condition=UnlessCondition(use_sim),
         output='screen',
     )
@@ -404,11 +407,10 @@ def launch_setup(context, *args, **kwargs):
     can_teardown = RegisterEventHandler(
         event_handler=OnShutdown(
             on_shutdown=[ExecuteProcess(
-                cmd=['bash', '-c', PythonExpression([
-                    "'sudo ip link set down vcan0 2>/dev/null || true' if '",
-                    use_sim,
-                    "' == 'true' else 'sudo ip link set down can0 2>/dev/null || true'"
-                ])],
+                cmd=['bash', '-c',
+                     'sudo -n ip link set down vcan0 2>/dev/null || true; '
+                     'sudo -n ip link set down can0 2>/dev/null || true; '
+                     'sudo -n killall slcand 2>/dev/null || true'],
                 output='screen',
             )],
         ),

--- a/src/subsystems/general/general_controllers/include/general_controllers/motor_status_broadcaster.hpp
+++ b/src/subsystems/general/general_controllers/include/general_controllers/motor_status_broadcaster.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "controller_interface/controller_interface.hpp"
@@ -69,6 +70,9 @@ protected:
 
   // Map from "joint/interface" to index in state_interfaces_
   std::unordered_map<std::string, size_t> state_interface_map_;
+  std::vector<std::string> joints_to_publish_;
+  std::vector<std::string> interfaces_to_publish_;
+  bool warned_no_interfaces_{false};
 
   // Publish rate limiting
   rclcpp::Duration publish_period_{0, 0};

--- a/src/subsystems/general/general_controllers/src/motor_status_broadcaster.cpp
+++ b/src/subsystems/general/general_controllers/src/motor_status_broadcaster.cpp
@@ -14,6 +14,7 @@
 
 #include "general_controllers/motor_status_broadcaster.hpp"
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 
@@ -50,10 +51,19 @@ controller_interface::InterfaceConfiguration
 MotorStatusBroadcaster::state_interface_configuration() const
 {
   controller_interface::InterfaceConfiguration config;
-  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  std::vector<std::string> interfaces = params_.interfaces;
+  if (interfaces.empty()) {
+    interfaces = {"motor_temperature", "torque_current"};
+  }
 
+  if (params_.joints.empty()) {
+    config.type = controller_interface::interface_configuration_type::ALL;
+    return config;
+  }
+
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
   for (const auto & joint : params_.joints) {
-    for (const auto & iface : params_.interfaces) {
+    for (const auto & iface : interfaces) {
       config.names.push_back(joint + "/" + iface);
     }
   }
@@ -67,13 +77,15 @@ controller_interface::CallbackReturn MotorStatusBroadcaster::on_configure(
   params_ = param_listener_->get_params();
 
   if (params_.joints.empty()) {
-    RCLCPP_ERROR(get_node()->get_logger(), "No joints specified for motor_status_broadcaster.");
-    return controller_interface::CallbackReturn::ERROR;
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "No joints specified for motor_status_broadcaster. Will publish any matching interfaces.");
   }
 
   if (params_.interfaces.empty()) {
-    RCLCPP_ERROR(get_node()->get_logger(), "No interfaces specified for motor_status_broadcaster.");
-    return controller_interface::CallbackReturn::ERROR;
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "No interfaces specified for motor_status_broadcaster. Using defaults: motor_temperature, torque_current.");
   }
 
   // Set up publish rate
@@ -104,12 +116,41 @@ controller_interface::CallbackReturn MotorStatusBroadcaster::on_activate(
                          state_interfaces_[i].get_interface_name()] = i;
   }
 
+  interfaces_to_publish_ = params_.interfaces;
+  if (interfaces_to_publish_.empty()) {
+    interfaces_to_publish_ = {"motor_temperature", "torque_current"};
+  }
+
+  joints_to_publish_.clear();
+  if (params_.joints.empty()) {
+    std::unordered_set<std::string> joints_set;
+    for (const auto & iface : state_interfaces_) {
+      const auto & iface_name = iface.get_interface_name();
+      if (std::find(interfaces_to_publish_.begin(), interfaces_to_publish_.end(), iface_name) !=
+          interfaces_to_publish_.end()) {
+        joints_set.insert(iface.get_prefix_name());
+      }
+    }
+    joints_to_publish_.assign(joints_set.begin(), joints_set.end());
+    std::sort(joints_to_publish_.begin(), joints_to_publish_.end());
+  } else {
+    joints_to_publish_ = params_.joints;
+  }
+
+  warned_no_interfaces_ = false;
+  if (joints_to_publish_.empty()) {
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "No motor telemetry interfaces found (motor_temperature/torque_current). Nothing to publish.");
+    warned_no_interfaces_ = true;
+  }
+
   last_publish_time_ = get_node()->now();
 
   RCLCPP_INFO(
     get_node()->get_logger(),
-    "MotorStatusBroadcaster activated with %zu state interfaces",
-    state_interfaces_.size());
+    "MotorStatusBroadcaster activated with %zu joints, %zu interfaces",
+    joints_to_publish_.size(), interfaces_to_publish_.size());
 
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -124,6 +165,16 @@ controller_interface::CallbackReturn MotorStatusBroadcaster::on_deactivate(
 controller_interface::return_type MotorStatusBroadcaster::update(
   const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
 {
+  if (joints_to_publish_.empty()) {
+    if (!warned_no_interfaces_) {
+      RCLCPP_WARN(
+        get_node()->get_logger(),
+        "No motor telemetry interfaces found (motor_temperature/torque_current). Nothing to publish.");
+      warned_no_interfaces_ = true;
+    }
+    return controller_interface::return_type::OK;
+  }
+
   // Rate limit publishing
   if (publish_period_.seconds() > 0.0 && (time - last_publish_time_) < publish_period_) {
     return controller_interface::return_type::OK;
@@ -133,14 +184,14 @@ controller_interface::return_type MotorStatusBroadcaster::update(
   diagnostic_msgs::msg::DiagnosticArray diag_msg;
   diag_msg.header.stamp = time;
 
-  for (const auto & joint : params_.joints) {
+  for (const auto & joint : joints_to_publish_) {
     diagnostic_msgs::msg::DiagnosticStatus status;
     status.name = "Motor: " + joint;
     status.hardware_id = joint;
     status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     status.message = "OK";
 
-    for (const auto & iface : params_.interfaces) {
+    for (const auto & iface : interfaces_to_publish_) {
       std::string key = joint + "/" + iface;
       auto it = state_interface_map_.find(key);
 

--- a/src/subsystems/science/science_bringup/launch/athena_science.launch.py
+++ b/src/subsystems/science/science_bringup/launch/athena_science.launch.py
@@ -303,20 +303,23 @@ def generate_launch_description():
     # -- CAN Setup (driven by use_sim) --
     can_setup_sim = ExecuteProcess(
         cmd=['bash', '-c',
-             'sudo modprobe vcan && '
-             'sudo ip link add dev vcan0 type vcan && '
-             'sudo ip link set up vcan0'],
+             'sudo modprobe vcan || true; '
+             'sudo ip link add dev vcan0 type vcan 2>/dev/null || true; '
+             'sudo ip link set up vcan0 || true'],
         condition=IfCondition(use_sim),
         output='screen',
     )
     can_setup_real = ExecuteProcess(
         cmd=['bash', '-c',
              'sudo killall slcand 2>/dev/null; sleep 1; '
-             'if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
-             'elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
-             'else echo "No CANable device found"; exit 1; fi && '
-             'sudo ip link set can0 up && '
-             'sudo ip link set can0 txqueuelen 1000'],
+             'if ip link show can0 >/dev/null 2>&1; then '
+             '  sudo ip link set can0 up && sudo ip link set can0 txqueuelen 1000; '
+             'else '
+             '  if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
+             '  elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
+             '  else echo "No CANable device found and can0 does not exist"; exit 1; fi && '
+             '  sudo ip link set can0 up && sudo ip link set can0 txqueuelen 1000; '
+             'fi'],
         condition=UnlessCondition(use_sim),
         output='screen',
     )
@@ -325,11 +328,10 @@ def generate_launch_description():
     can_teardown = RegisterEventHandler(
         event_handler=OnShutdown(
             on_shutdown=[ExecuteProcess(
-                cmd=['bash', '-c', PythonExpression([
-                    "'sudo ip link set down vcan0 2>/dev/null || true' if '",
-                    use_sim,
-                    "' == 'true' else 'sudo ip link set down can0 2>/dev/null || true'"
-                ])],
+                cmd=['bash', '-c',
+                     'sudo -n ip link set down vcan0 2>/dev/null || true; '
+                     'sudo -n ip link set down can0 2>/dev/null || true; '
+                     'sudo -n killall slcand 2>/dev/null || true'],
                 output='screen',
             )],
         ),

--- a/src/subsystems/science/science_bringup/launch/athena_science.launch.py
+++ b/src/subsystems/science/science_bringup/launch/athena_science.launch.py
@@ -20,17 +20,24 @@
 #
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, RegisterEventHandler, TimerAction
-from launch.event_handlers import OnProcessExit, OnProcessStart
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler, TimerAction, ExecuteProcess
+from launch.conditions import IfCondition, UnlessCondition
+from launch.event_handlers import OnProcessExit, OnProcessStart, OnShutdown
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch.actions import TimerAction
 
 
 def generate_launch_description():
     # Declare arguments
     declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim",
+            default_value="false",
+            description="Simulation mode: enables mock hardware and virtual CAN (vcan0).",
+        )
+    )
     declared_arguments.append(
         DeclareLaunchArgument(
             "runtime_config_package",
@@ -74,15 +81,16 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "use_mock_hardware",
             default_value="false",
-            description="Start robot with mock hardware mirroring command to its states.",
+            description="Start robot with mock hardware mirroring command to its states. "
+                        "Automatically true when use_sim is true.",
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "mock_sensor_commands",
             default_value="false",
-            description="Enable mock command interfaces for sensors used for simple simulations. \
-            Used only if 'use_mock_hardware' parameter is true.",
+            description="Enable mock command interfaces for sensors used for simple simulations. "
+                        "Automatically true when use_sim is true.",
         )
     )
 
@@ -96,6 +104,7 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
+    use_sim = LaunchConfiguration("use_sim")
     runtime_config_package = LaunchConfiguration("runtime_config_package")
     controllers_file = LaunchConfiguration("controllers_file")
     description_package = LaunchConfiguration("description_package")
@@ -104,6 +113,14 @@ def generate_launch_description():
     use_mock_hardware = LaunchConfiguration("use_mock_hardware")
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
+
+    # When use_sim is true, force mock hardware and mock sensor commands on
+    use_mock_hardware_effective = PythonExpression([
+        "'true' if '", use_sim, "' == 'true' else '", use_mock_hardware, "'"
+    ])
+    mock_sensor_commands_effective = PythonExpression([
+        "'true' if '", use_sim, "' == 'true' else '", mock_sensor_commands, "'"
+    ])
 
     # Get URDF via xacro
     robot_description_content = Command(
@@ -118,10 +135,13 @@ def generate_launch_description():
             prefix,
             " ",
             "use_mock_hardware:=",
-            use_mock_hardware,
+            use_mock_hardware_effective,
             " ",
             "mock_sensor_commands:=",
-            mock_sensor_commands,
+            mock_sensor_commands_effective,
+            " ",
+            "use_sim:=",
+            use_sim,
             " ",
         ]
     )
@@ -183,22 +203,9 @@ def generate_launch_description():
         arguments=["motor_status_broadcaster", "-c", "/controller_manager"],
     )
 
-    # CONTROLLER MANAGERS
-
-    '''robot_controller_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=["joint_trajectory_controller", "--param-file", robot_controllers]
-    )'''
-
-    '''velocity_controller_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=["velocity_controller", "--param-file", robot_controllers, "--inactive"]
-    )'''
 
     # Active Spawners
-    robot_controller_names = ["science_controller"] # robot_controller
+    robot_controller_names = ["science_controller"]
     robot_controller_spawners = [] 
     for controller in robot_controller_names:
         robot_controller_spawners += [
@@ -222,7 +229,7 @@ def generate_launch_description():
         ]
 
     inactive_robot_controller_names = ["joint_group_velocity_controller", "joint_group_position_controller"]
-    inactive_robot_controller_spawners = [] # Set the ones you want inactive in the beginning (e.g., velocity controller, etc.)
+    inactive_robot_controller_spawners = []
     for controller in inactive_robot_controller_names:
         inactive_robot_controller_spawners += [
             Node(
@@ -290,7 +297,42 @@ def generate_launch_description():
             executable='can_node',
             name='can_node',
             output='log',
-            arguments=['--ros-args', '--log-level', 'fatal'] # prevents can node from outputting to terminal
+            arguments=['--ros-args', '--log-level', 'fatal']
+    )
+
+    # -- CAN Setup (driven by use_sim) --
+    can_setup_sim = ExecuteProcess(
+        cmd=['bash', '-c',
+             'sudo modprobe vcan && '
+             'sudo ip link add dev vcan0 type vcan && '
+             'sudo ip link set up vcan0'],
+        condition=IfCondition(use_sim),
+        output='screen',
+    )
+    can_setup_real = ExecuteProcess(
+        cmd=['bash', '-c',
+             'sudo killall slcand 2>/dev/null; sleep 1; '
+             'if [ -e /dev/ttyACM0 ]; then sudo slcand -o -c -s8 /dev/ttyACM0 can0; '
+             'elif [ -e /dev/ttyACM1 ]; then sudo slcand -o -c -s8 /dev/ttyACM1 can0; '
+             'else echo "No CANable device found"; exit 1; fi && '
+             'sudo ip link set can0 up && '
+             'sudo ip link set can0 txqueuelen 1000'],
+        condition=UnlessCondition(use_sim),
+        output='screen',
+    )
+
+    # -- CAN Teardown on Shutdown --
+    can_teardown = RegisterEventHandler(
+        event_handler=OnShutdown(
+            on_shutdown=[ExecuteProcess(
+                cmd=['bash', '-c', PythonExpression([
+                    "'sudo ip link set down vcan0 2>/dev/null || true' if '",
+                    use_sim,
+                    "' == 'true' else 'sudo ip link set down can0 2>/dev/null || true'"
+                ])],
+                output='screen',
+            )],
+        ),
     )
 
     # Delay loading and activation of robot_controller_names after `joint_state_broadcaster`
@@ -328,6 +370,9 @@ def generate_launch_description():
     return LaunchDescription(
         declared_arguments
         + [
+            can_setup_sim,
+            can_setup_real,
+            can_teardown,
             control_node,
             robot_state_pub_node,
             rviz_node,

--- a/src/tools/scripts/dev_can_setup.sh
+++ b/src/tools/scripts/dev_can_setup.sh
@@ -1,0 +1,2 @@
+sudo ip link add dev can0 type vcan
+sudo ip link set up can0

--- a/src/tools/scripts/virtual_can_setup.sh
+++ b/src/tools/scripts/virtual_can_setup.sh
@@ -1,2 +1,2 @@
-sudo ip link add dev can0 type vcan
-sudo ip link set up can0
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0


### PR DESCRIPTION
Replaces per-subsystem can_interface arguments with a single use_sim toggle across arm, drive, and science. When use_sim is true:
CAN interface switches to vcan0 (otherwise can0)
use_mock_hardware and mock_sensor_commands are auto-enabled
CAN setup/teardown runs directly from launch files (virtual or real)
Arm: MoveIt and JTC activate on startup; JTC remains available but inactive on real hardware
Also parameterizes use_sim_time in navigation, renames the old use_sim (RViz toggle) to use_rviz, fixes ODrive parameter key (can → can_interface), and corrects virtual_can_setup.sh to use vcan0