### PR TITLE
Joy Config + Xbox & Airbus integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,9 +178,9 @@ cython_debug/
 # Prerequisites
 *.d
 
-
+# AI
 .kiro
-
+.claude
 
 # Compiled Object files
 *.slo
@@ -212,4 +212,3 @@ cython_debug/
 
 .DS_Store
 *.mcap
-

--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,10 @@ cython_debug/
 # Prerequisites
 *.d
 
+
+.kiro
+
+
 # Compiled Object files
 *.slo
 *.lo
@@ -208,3 +212,4 @@ cython_debug/
 
 .DS_Store
 *.mcap
+

--- a/src/subsystems/arm/arm_bringup/config/joystick.yaml
+++ b/src/subsystems/arm/arm_bringup/config/joystick.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    joystick_type: "xbox"
+    joystick_type: "airbus"
 
     # can ids
     base_yaw_id: 5

--- a/src/subsystems/arm/arm_bringup/config/joystick.yaml
+++ b/src/subsystems/arm/arm_bringup/config/joystick.yaml
@@ -1,8 +1,6 @@
 /**:
   ros__parameters:
-    # 0: PS4    1: Thrustmaster    2: Xbox One    3: 8BitDo Ultimate
-    joystick_type: 2
-    joystick_index: -1
+    joystick_type: "xbox"
 
     # can ids
     base_yaw_id: 5

--- a/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
+++ b/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
@@ -193,7 +193,7 @@ def launch_setup(context, *args, **kwargs):
         executable='joystick',
         name='joystick',
         output='screen',
-        parameters=[joystick_config_file],
+        parameters=[joystick_config_file, {'subsystem': 'arm'}],
     )
 
     control_node = Node(

--- a/src/subsystems/arm/arm_controllers/config/manual_arm_cylindrical_controller.yaml
+++ b/src/subsystems/arm/arm_controllers/config/manual_arm_cylindrical_controller.yaml
@@ -50,7 +50,7 @@ manual_arm_cylindrical_controller:
   }
   joystick_topic: {
     type: string,
-    default_value: "controller_input/xbox",
+    default_value: "controller_input/airbus",
     description: "Topic name for joystick input (sensor_msgs/Joy).",
     read_only: true,
     validation: {

--- a/src/subsystems/arm/arm_controllers/config/manual_arm_cylindrical_controller.yaml
+++ b/src/subsystems/arm/arm_controllers/config/manual_arm_cylindrical_controller.yaml
@@ -48,6 +48,15 @@ manual_arm_cylindrical_controller:
       forbidden_interface_name_prefix: null
     }
   }
+  joystick_topic: {
+    type: string,
+    default_value: "controller_input/xbox",
+    description: "Topic name for joystick input (sensor_msgs/Joy).",
+    read_only: true,
+    validation: {
+      not_empty<>: null,
+    }
+  }
   joint_lengths: {
     type: double_array,
     default_value: [],

--- a/src/subsystems/arm/arm_controllers/config/manual_arm_joint_by_joint_controller.yaml
+++ b/src/subsystems/arm/arm_controllers/config/manual_arm_joint_by_joint_controller.yaml
@@ -60,7 +60,7 @@ manual_arm_joint_by_joint_controller:
   # }
   joystick_topic: {
     type: string,
-    default_value: "controller_input/xbox",
+    default_value: "controller_input/airbus",
     description: "Topic name for joystick input (sensor_msgs/Joy).",
     read_only: true,
     validation: {

--- a/src/subsystems/arm/arm_controllers/config/manual_arm_joint_by_joint_controller.yaml
+++ b/src/subsystems/arm/arm_controllers/config/manual_arm_joint_by_joint_controller.yaml
@@ -58,6 +58,15 @@ manual_arm_joint_by_joint_controller:
   #     forbidden_interface_name_prefix: null
   #   }
   # }
+  joystick_topic: {
+    type: string,
+    default_value: "controller_input/xbox",
+    description: "Topic name for joystick input (sensor_msgs/Joy).",
+    read_only: true,
+    validation: {
+      not_empty<>: null,
+    }
+  }
   joint_max_velocities: {
     type: double_array,
     default_value: [],

--- a/src/subsystems/arm/arm_controllers/include/athena_arm_controllers/manual_arm_cylindrical_controller.hpp
+++ b/src/subsystems/arm/arm_controllers/include/athena_arm_controllers/manual_arm_cylindrical_controller.hpp
@@ -54,7 +54,7 @@ static constexpr size_t CMD_MY_ITFS = 0;
 static constexpr int joystick_axes = 6;
 
 // amount of joystick buttons
-static constexpr int joystick_buttons = 13;
+static constexpr int joystick_buttons = 17;
 
 // name constants for amount of velocities being commanded (yaw, y, z, thetadot, wrist roll, open claw, close claw)
 static constexpr size_t CMD_VELOCITIES_SIZE = 7;

--- a/src/subsystems/arm/arm_controllers/include/athena_arm_controllers/manual_arm_joint_by_joint_controller.hpp
+++ b/src/subsystems/arm/arm_controllers/include/athena_arm_controllers/manual_arm_joint_by_joint_controller.hpp
@@ -32,7 +32,7 @@ static constexpr size_t CMD_MY_ITFS = 0;
 static constexpr int joystick_axes = 6;
 
 // amount of joystick buttons
-static constexpr int joystick_buttons = 13;
+static constexpr int joystick_buttons = 17;
 
 // TODO(anyone: example setup for control mode (usually you will use some enums defined in messages)
 enum class control_mode_type : std::uint8_t

--- a/src/subsystems/arm/arm_controllers/src/manual_arm_cylindrical_controller.cpp
+++ b/src/subsystems/arm/arm_controllers/src/manual_arm_cylindrical_controller.cpp
@@ -110,7 +110,7 @@ controller_interface::CallbackReturn ManualArmCylindricalController::on_configur
 
   // Reference Subscriber
   ref_subscriber_ = get_node()->create_subscription<ControllerReferenceMsg>(
-    "controller_input", subscribers_qos,
+    params_.joystick_topic, subscribers_qos,
     std::bind(&ManualArmCylindricalController::reference_callback, this, std::placeholders::_1));
   
   // Create, populate with NaN, and write message to input_ref_ to be used in reference callback
@@ -244,9 +244,9 @@ controller_interface::return_type ManualArmCylindricalController::update(
   if (!std::isnan((*current_ref)->axes[0]))
   {
     //TODO: Get rid of the hardcoded rigamarole (translates to max vel of 1.5 inches/s)
-    command_velocities_[0] = (*current_ref)->axes[2]*0.174533; // l/r right joystick -> yaw 10 dps
+    command_velocities_[0] = (*current_ref)->axes[2]*0.174533; // joystick_y -> yaw 10 dps
     command_velocities_[1] = (*current_ref)->axes[1]*6*0.00635; // u/d left joystick -> vy
-    command_velocities_[2] = (*current_ref)->axes[3]*6*0.00635; // u/d right joystick -> vz
+    command_velocities_[2] = (*current_ref)->axes[3]*6*0.00635; // joystick_x -> vz
     command_velocities_[3] = (*current_ref)->axes[1] * static_cast<float>((*current_ref)->buttons[1]);  // u/d left joystick & circle -> thetadot
     command_velocities_[4] = 0.0; // (*current_ref)->axes[0]; // l/r left joystick -> wrist roll
     command_velocities_[5] = (*current_ref)->axes[4]; // left trigger -> open claw

--- a/src/subsystems/arm/arm_controllers/src/manual_arm_joint_by_joint_controller.cpp
+++ b/src/subsystems/arm/arm_controllers/src/manual_arm_joint_by_joint_controller.cpp
@@ -92,7 +92,7 @@ controller_interface::CallbackReturn ManualArmJointByJointController::on_configu
 
   // Reference Subscriber
   ref_subscriber_ = get_node()->create_subscription<ControllerReferenceMsg>(
-    "controller_input", subscribers_qos,
+    params_.joystick_topic, subscribers_qos,
     std::bind(&ManualArmJointByJointController::reference_callback, this, std::placeholders::_1));
   
   // Create, populate with NaN, and write message to input_ref_ to be used in reference callback

--- a/src/subsystems/drive/drive_bringup/config/joystick.yaml
+++ b/src/subsystems/drive/drive_bringup/config/joystick.yaml
@@ -1,3 +1,3 @@
 /**:
   ros__parameters:
-    joystick_type: "thrustmaster t.16000m"
+    joystick_type: "thrustmaster"

--- a/src/subsystems/drive/drive_bringup/config/joystick.yaml
+++ b/src/subsystems/drive/drive_bringup/config/joystick.yaml
@@ -1,4 +1,3 @@
 /**:
   ros__parameters:
-    # 0: PS4    1: Thrustmaster
-    joystick_type: 1
+    joystick_type: "thrustmaster t.16000m"

--- a/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
+++ b/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
@@ -1,3 +1,5 @@
+import yaml
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction, RegisterEventHandler, TimerAction
 from launch.conditions import IfCondition
@@ -167,15 +169,18 @@ def launch_setup(context, *args, **kwargs):
 
     robot_description = {"robot_description": robot_description_content}
 
+    with open(joystick_config.perform(context), 'r') as f:
+        joy_cfg = yaml.safe_load(f)
+    joystick_type = joy_cfg['/**']['ros__parameters']['joystick_type']
+
     joystick_publisher = Node(
         package='teleop',
         executable='joystick',
         name='joystick',
         output='screen',
-        parameters=[joystick_config],
+        parameters=[joystick_config, {'subsystem': 'drive'}],
         remappings=[
-            ('controller_input', 'joy'),
-            ('/controller_input', '/joy'),
+            (f'controller_input/{joystick_type}', 'joy'),
         ],
     )
 

--- a/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
+++ b/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
@@ -179,9 +179,6 @@ def launch_setup(context, *args, **kwargs):
         name='joystick',
         output='screen',
         parameters=[joystick_config, {'subsystem': 'drive'}],
-        remappings=[
-            (f'controller_input/{joystick_type}', 'joy'),
-        ],
     )
 
     teleop_twist_joy = Node(
@@ -191,6 +188,7 @@ def launch_setup(context, *args, **kwargs):
         output='screen',
         parameters=[teleop_twist_config],
         remappings=[
+            ('joy', f'controller_input/{joystick_type}'),
             ('/cmd_vel', '/rear_ackermann_controller/reference'),
         ],
     )

--- a/src/subsystems/science/science_bringup/config/joystick.yaml
+++ b/src/subsystems/science/science_bringup/config/joystick.yaml
@@ -1,4 +1,3 @@
 /**:
   ros__parameters:
-    # 0: PS4    1: Thrustmaster
-    joystick_type: 0
+    joystick_type: "xbox"

--- a/src/subsystems/science/science_bringup/launch/athena_science.launch.py
+++ b/src/subsystems/science/science_bringup/launch/athena_science.launch.py
@@ -144,11 +144,7 @@ def generate_launch_description():
         executable='joystick',
         name='joystick',
         output='screen',
-        parameters = [joystick_config_file],
-        remappings=[
-        ('controller_input', 'science_manual'),
-        ('/controller_input', '/science_manual'),
-    ],
+        parameters=[joystick_config_file, {'subsystem': 'science'}],
     )
 
     control_node = Node(

--- a/src/subsystems/science/science_controllers/src/science_controller.cpp
+++ b/src/subsystems/science/science_controllers/src/science_controller.cpp
@@ -293,8 +293,8 @@ controller_interface::return_type ScienceManual::update(
   // rack_left_position  += axis_left  * rack_speed * left_gain * dt;
   // rack_right_position -= axis_right * rack_speed * right_gain * dt;
 
-  // ** TEMPORARY FOR SAR
-  bool lift_button = (msg->buttons.size() > 11 && msg->buttons[12]);
+  // ** TEMPORARY FOR SAR 
+  bool lift_button = (msg->buttons.size() > 1 && msg->buttons[1]);
   if (lift_button && !prev_lift_button) {
     lift_toggle = !lift_toggle;
   }

--- a/src/subsystems/science/science_controllers/src/science_controller.cpp
+++ b/src/subsystems/science/science_controllers/src/science_controller.cpp
@@ -146,7 +146,7 @@ controller_interface::CallbackReturn ScienceManual::on_configure(
 
   // Reference subscriber
   ref_subscriber_ = get_node()->create_subscription<ControllerReferenceMsg>(
-    "/science_manual", subscribers_qos,
+    params_.joystick_topic, subscribers_qos,
     std::bind(&ScienceManual::reference_callback, this, std::placeholders::_1));
 
   std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
@@ -155,7 +155,7 @@ controller_interface::CallbackReturn ScienceManual::on_configure(
 
   // State publisher
   s_publisher_ = get_node()->create_publisher<ControllerStateMsg>(
-    "/science_manual/state", rclcpp::QoS(rclcpp::KeepLast(1)));
+    params_.joystick_topic + "/state", rclcpp::QoS(rclcpp::KeepLast(1)));
   state_publisher_ = std::make_unique<ControllerStatePublisher>(s_publisher_);
 
   if (state_publisher_ && state_publisher_->trylock()) {

--- a/src/subsystems/science/science_controllers/src/science_controller.yaml
+++ b/src/subsystems/science/science_controllers/src/science_controller.yaml
@@ -2,6 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # ...
 science_manual:
+  joystick_topic:
+    type: string
+    default_value: "controller_input/xbox"
+    description: "Topic name for joystick input (sensor_msgs/Joy)."
+    read_only: true
+    validation:
+      not_empty<>: null
+
   state_joints:
     type: string_array
     default_value: []

--- a/src/teleop/teleop/config/joy.yaml
+++ b/src/teleop/teleop/config/joy.yaml
@@ -1,0 +1,27 @@
+/**:
+  ros__parameters:
+    controllers:
+      xbox:
+        axes:
+        - { name: "left_stick_lr",  axis: 0, invert: false, trigger: false }
+        - { name: "left_stick_ud",  axis: 1, invert: false, trigger: false }
+        - { name: "left_trigger",   axis: 2, invert: false, trigger: true  }
+        - { name: "right_stick_lr", axis: 3, invert: false, trigger: false }
+        - { name: "right_stick_ud", axis: 4, invert: false, trigger: false }
+        - { name: "right_trigger",  axis: 5, invert: false, trigger: true  }
+      thrustmaster t.16000m:
+        axes:
+        - { name: "joystick_twist",   axis: 0, invert: false, trigger: false }
+        - { name: "joystick_x",       axis: 1, invert: true,  trigger: false }
+        - { name: "joystick_y",       axis: 2, invert: false, trigger: false }
+        - { name: "throttle_level",   axis: 3, invert: true,  trigger: false }
+        - { name: "hat_switch_y",     axis: 4, invert: true,  trigger: false }
+        - { name: "hat_switch_x",     axis: 5, invert: false, trigger: false }
+
+    subsystems:
+      arm:
+        output_slots: [left_stick_lr, left_stick_ud, right_stick_lr, right_stick_ud, left_trigger, right_trigger]
+      science:
+        output_slots: [left_stick_lr, left_stick_ud, right_stick_lr, right_stick_ud, left_trigger, right_trigger]
+      drive:
+        output_slots: [joystick_twist, joystick_x, joystick_y, throttle_level, hat_switch_y, hat_switch_x]

--- a/src/teleop/teleop/config/joy.yaml
+++ b/src/teleop/teleop/config/joy.yaml
@@ -17,10 +17,18 @@
         - { name: "throttle_level",   axis: 3, invert: true,  trigger: true }
         - { name: "hat_switch_y",     axis: 4, invert: true,  trigger: false }
         - { name: "hat_switch_x",     axis: 5, invert: false, trigger: false }
+      airbus:
+        axes:
+        - { name: "joystick_twist",   axis: 0, invert: false, trigger: false }
+        - { name: "joystick_x",       axis: 1, invert: false, trigger: false }
+        - { name: "joystick_y",       axis: 2, invert: false, trigger: false }
+        - { name: "throttle_level",   axis: 3, invert: false, trigger: true  }
+        - { name: "hat_switch_y",     axis: 4, invert: false, trigger: false }
+        - { name: "hat_switch_x",     axis: 5, invert: false, trigger: false }
 
     subsystems:
       arm:
-        output_slots: [left_stick_lr, left_stick_ud, right_stick_lr, right_stick_ud, left_trigger, right_trigger]
+        output_slots: [joystick_y, joystick_x, joystick_twist, throttle_level, hat_switch_y, hat_switch_x]
       science:
         output_slots: [left_stick_lr, left_stick_ud, right_stick_lr, right_stick_ud, left_trigger, right_trigger]
       drive:

--- a/src/teleop/teleop/config/joy.yaml
+++ b/src/teleop/teleop/config/joy.yaml
@@ -30,15 +30,18 @@
       arm:
         # Controller: Airbus TCA Sidestick (joystick_type: airbus)
 
-        # Slot → axis name → Joint-by-Joint use              | Cylindrical use
-        # [0]  joystick_y     → base yaw / wrist roll*       | unused
+        # Slot → axis name → Joint-by-Joint use               | Cylindrical use
+        # [0]  joystick_y     → base yaw / wrist roll*        | unused
         # [1]  joystick_x     → shoulder pitch / wrist pitch* | vy (reach in/out) / theta-dot*
         # [2]  joystick_twist → unused                        | yaw (rotate base)
         # [3]  throttle_level → elbow pitch                   | vz (height)
-        # [4]  hat_switch_y   → gripper open  (dead slot — always 0, gripper uses buttons[4])
-        # [5]  hat_switch_x   → gripper close (dead slot — always 0, gripper uses buttons[5])
+        # [4]  hat_switch_y   → unused (dead slot)
+        # [5]  hat_switch_x   → unusued (dead slot)
 
-        # * modifier = buttons[1]; buttons[3] = actuator trigger
+        # center button(buttons[1]) = *modifier
+        # red button(buttons[3]) = actuator trigger
+        # left 1 (buttons[4]) = gripper open
+        #left 2 (buttons[5]) = gripper close
         output_slots: [joystick_y, joystick_x, joystick_twist, throttle_level, hat_switch_y, hat_switch_x]
       
       science:
@@ -46,13 +49,19 @@
 
         # Slot → axis name       → use
         # [0]  left_stick_lr    → auger lift
-        # [1]  left_stick_ud    → linear actuator left / sampler lift
-        # [2]  left_trigger     → unused
-        # [3]  right_stick_lr   → linear actuator right / sampler lift
-        # [4]  right_stick_ud   → auger spin (reverse via buttons[4])
+        # [1]  left_stick_ud    → unused
+        # [2]  right_stick_lr   → unused
+        # [3]  right_stick_ud   → sampler lift
+        # [4]  left_trigger     → auger spin (reverse via buttons[4])
         # [5]  right_trigger    → scoop (reverse via buttons[5])
 
-        # buttons[0] = servo scoop B, buttons[2] = pump, buttons[3] = servo scoop A, buttons[12] = lift
+        # A(buttons[0]) = servo scoop B (toggle)
+        # B(buttons[1]) = rack & pinion lift (toggle between two hardcoded positions)
+        # X(buttons[2]) = pump (toggle)
+        # Y(buttons[3]) = servo scoop A (toggle)
+        # LB(buttons[4]) = reverse auger spin
+        # RB(buttons[5]) = reverse scoop
+        
         output_slots: [left_stick_lr, left_stick_ud, right_stick_lr, right_stick_ud, left_trigger, right_trigger]
 
       
@@ -61,9 +70,9 @@
         # All 6 axes published in order → remapped to /joy → consumed by teleop_twist_joy
         # Slot → axis name       → use
         # [0]  joystick_twist   → steering (angular velocity)
-        # [1]  joystick_x       → unused by twist joy
+        # [1]  joystick_x       → forward/reverse speed (linear velocity)
         # [2]  joystick_y       → unused by twist joy
-        # [3]  throttle_level   → forward/reverse speed (linear velocity)
+        # [3]  throttle_level   → unused by twist joy
         # [4]  hat_switch_y     → unused
         # [5]  hat_switch_x     → unused
         output_slots: [joystick_twist, joystick_x, joystick_y, throttle_level, hat_switch_y, hat_switch_x]

--- a/src/teleop/teleop/config/joy.yaml
+++ b/src/teleop/teleop/config/joy.yaml
@@ -14,7 +14,7 @@
         - { name: "joystick_twist",   axis: 0, invert: false, trigger: false }
         - { name: "joystick_x",       axis: 1, invert: true,  trigger: false }
         - { name: "joystick_y",       axis: 2, invert: false, trigger: false }
-        - { name: "throttle_level",   axis: 3, invert: true,  trigger: true }
+        - { name: "throttle_level",   axis: 3, invert: false,  trigger: true, range_inverted: true }
         - { name: "hat_switch_y",     axis: 4, invert: true,  trigger: false }
         - { name: "hat_switch_x",     axis: 5, invert: false, trigger: false }
       airbus:
@@ -22,14 +22,48 @@
         - { name: "joystick_twist",   axis: 0, invert: false, trigger: false }
         - { name: "joystick_x",       axis: 1, invert: false, trigger: false }
         - { name: "joystick_y",       axis: 2, invert: false, trigger: false }
-        - { name: "throttle_level",   axis: 3, invert: false, trigger: true  }
+        - { name: "throttle_level",   axis: 3, invert: false, trigger: true, range_inverted: true }
         - { name: "hat_switch_y",     axis: 4, invert: false, trigger: false }
         - { name: "hat_switch_x",     axis: 5, invert: false, trigger: false }
 
     subsystems:
       arm:
+        # Controller: Airbus TCA Sidestick (joystick_type: airbus)
+
+        # Slot → axis name → Joint-by-Joint use              | Cylindrical use
+        # [0]  joystick_y     → base yaw / wrist roll*       | unused
+        # [1]  joystick_x     → shoulder pitch / wrist pitch* | vy (reach in/out) / theta-dot*
+        # [2]  joystick_twist → unused                        | yaw (rotate base)
+        # [3]  throttle_level → elbow pitch                   | vz (height)
+        # [4]  hat_switch_y   → gripper open  (dead slot — always 0, gripper uses buttons[4])
+        # [5]  hat_switch_x   → gripper close (dead slot — always 0, gripper uses buttons[5])
+
+        # * modifier = buttons[1]; buttons[3] = actuator trigger
         output_slots: [joystick_y, joystick_x, joystick_twist, throttle_level, hat_switch_y, hat_switch_x]
+      
       science:
+        # Controller: Xbox (joystick_type: xbox)
+
+        # Slot → axis name       → use
+        # [0]  left_stick_lr    → auger lift
+        # [1]  left_stick_ud    → linear actuator left / sampler lift
+        # [2]  left_trigger     → unused
+        # [3]  right_stick_lr   → linear actuator right / sampler lift
+        # [4]  right_stick_ud   → auger spin (reverse via buttons[4])
+        # [5]  right_trigger    → scoop (reverse via buttons[5])
+
+        # buttons[0] = servo scoop B, buttons[2] = pump, buttons[3] = servo scoop A, buttons[12] = lift
         output_slots: [left_stick_lr, left_stick_ud, right_stick_lr, right_stick_ud, left_trigger, right_trigger]
+
+      
       drive:
+        # Controller: Thrustmaster T.16000M (joystick_type: thrustmaster)
+        # All 6 axes published in order → remapped to /joy → consumed by teleop_twist_joy
+        # Slot → axis name       → use
+        # [0]  joystick_twist   → steering (angular velocity)
+        # [1]  joystick_x       → unused by twist joy
+        # [2]  joystick_y       → unused by twist joy
+        # [3]  throttle_level   → forward/reverse speed (linear velocity)
+        # [4]  hat_switch_y     → unused
+        # [5]  hat_switch_x     → unused
         output_slots: [joystick_twist, joystick_x, joystick_y, throttle_level, hat_switch_y, hat_switch_x]

--- a/src/teleop/teleop/config/joy.yaml
+++ b/src/teleop/teleop/config/joy.yaml
@@ -4,17 +4,17 @@
       xbox:
         axes:
         - { name: "left_stick_lr",  axis: 0, invert: false, trigger: false }
-        - { name: "left_stick_ud",  axis: 1, invert: false, trigger: false }
+        - { name: "left_stick_ud",  axis: 1, invert: true, trigger: false }
         - { name: "left_trigger",   axis: 2, invert: false, trigger: true  }
         - { name: "right_stick_lr", axis: 3, invert: false, trigger: false }
-        - { name: "right_stick_ud", axis: 4, invert: false, trigger: false }
+        - { name: "right_stick_ud", axis: 4, invert: true, trigger: false }
         - { name: "right_trigger",  axis: 5, invert: false, trigger: true  }
-      thrustmaster t.16000m:
+      thrustmaster:
         axes:
         - { name: "joystick_twist",   axis: 0, invert: false, trigger: false }
         - { name: "joystick_x",       axis: 1, invert: true,  trigger: false }
         - { name: "joystick_y",       axis: 2, invert: false, trigger: false }
-        - { name: "throttle_level",   axis: 3, invert: true,  trigger: false }
+        - { name: "throttle_level",   axis: 3, invert: true,  trigger: true }
         - { name: "hat_switch_y",     axis: 4, invert: true,  trigger: false }
         - { name: "hat_switch_x",     axis: 5, invert: false, trigger: false }
 

--- a/src/teleop/teleop/setup.py
+++ b/src/teleop/teleop/setup.py
@@ -10,6 +10,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/config', ['config/joy.yaml']),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/src/teleop/teleop/teleop/joystick_publisher.py
+++ b/src/teleop/teleop/teleop/joystick_publisher.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import os
 import time
-import pprint
 import pygame
 import numpy as np
+
+import yaml
+from ament_index_python.packages import get_package_share_directory
+
 
 import rclpy
 from rclpy.node import Node
@@ -15,31 +18,37 @@ class JoystickPublisher(Node):
     def __init__(self):
    
         super().__init__('joystick')
-        self.publisher_ = self.create_publisher(Joy, 'controller_input', 10)
         timer_period = 0.1  # seconds
-        self.timer = self.create_timer(timer_period, self.controller_inputs)       
+        self.timer = self.create_timer(timer_period, self.controller_inputs)
 
 
         # Parameters
         self.declare_parameters(
             namespace='',
             parameters=[
-                ('joystick_type', rclpy.Parameter.Type.INTEGER),
-                ('joystick_index', rclpy.Parameter.Type.INTEGER),
+                ('joystick_type', rclpy.Parameter.Type.STRING),
+                ('subsystem' , rclpy.Parameter.Type.STRING),
             ]
         )
-
-        self.possible_joysticks = [
-            "sony computer entertainment wireless controller",
-            "thrustmaster t.16000m",
-            "xbox one s controller",
-            "8bitdo ultimate wireless controller",
-        ]
-
-        # 0: PS4 1: Thrustmaster 2: Xbox One 3: 8BitDo Ultimate
         self.joystick_type = self.get_parameter('joystick_type').value
-        self.requested_joystick_index = self.get_parameter('joystick_index').value
+        self.subsystem = self.get_parameter('subsystem').value
+        self.publisher_ = self.create_publisher(Joy, f'controller_input/{self.joystick_type}', 10)
+
         self.get_logger().info(f"Joystick type: {self.joystick_type}")
+        self.get_logger().info(f"Subsystem: {self.subsystem}")
+
+        joy_yaml_path = os.path.join(get_package_share_directory('teleop'), 'config', 'joy.yaml')
+        with open(joy_yaml_path, 'r') as f:
+            config = yaml.safe_load(f)
+
+
+        axes_list = config['ros__parameters']['controllers'][self.joystick_type]['axes']
+
+        self._axes_config = {e['name']: e for e in axes_list}
+        slots = config['ros__parameters']['subsystems'][self.subsystem]['output_slots']
+        self._slot_params = [self._axes_config[name] for name in slots]
+
+        
 
         # Detect Jetson platform
         self.is_jetson = False
@@ -66,22 +75,12 @@ class JoystickPublisher(Node):
         joysticks = pygame.joystick.get_count()
         self.get_logger().info(f"Number of joysticks found: {joysticks}")
 
-        if 0 <= self.requested_joystick_index < joysticks:
-            self.joystick_index = self.requested_joystick_index
-            self.get_logger().info(f"Using configured joystick index: {self.joystick_index}")
-        else:
-            for i in range(joysticks):
-                js = pygame.joystick.Joystick(i)
-                name = js.get_name().lower()
-                self.get_logger().info(f"Joystick {i}: {name}")
-                expected_name = self.possible_joysticks[self.joystick_type]
-                if(
-                    name == expected_name or
-                    (self.joystick_type == 2 and "xbox" in name) or
-                    (self.joystick_type == 3 and ("8bitdo" in name or "ultimate" in name))
-                ):
-                    self.joystick_index = i
-                    break
+        for i in range(joysticks):
+            js = pygame.joystick.Joystick(i)
+            name = js.get_name().lower()
+            if(name == self.joystick_type):
+                self.joystick_index = i
+                break
 
         # Only begin once a joystick is connected
         while(joysticks == 0):
@@ -118,8 +117,20 @@ class JoystickPublisher(Node):
             for i in range(self.controller.get_numhats()):
                 self.hat_data[i] = (0, 0)
 
-        self.previous_axes = np.zeros(6)
+        self.previous_axes = np.zeros(len(self._slot_params))
         self.previous_buttons = np.zeros(13)        
+
+    def _normalize(self, raw, invert, trigger):
+        if abs(raw) < self.activation:
+            val = 0.0
+        else:
+            val = (abs(raw) - self.activation) / (1.0 - self.activation)
+            val = val if raw > 0 else -val
+        if trigger:
+            val = (val + 1.0) / 2.0
+        if invert:
+            val = -val
+        return val
 
     def controller_inputs(self):
        
@@ -135,239 +146,18 @@ class JoystickPublisher(Node):
             elif event.type == pygame.JOYHATMOTION:
                 self.hat_data[event.hat] = event.value
 
-        if(self.joystick_type == 0):
+            
+            #axes normalization
+            for i, slot in enumerate(self._slot_params):
+                joystick_vels[i] = self._normalize(
+                    self.axis_data.get(slot['axis'], 0.0),
+                    slot['invert'],
+                    slot['trigger']
+                )
 
-                """
-                PS4 Controller:
-                Joystick Velocities
-                [0] = l/r left joystick
-                [1] = u/d left joystick
-                [2] = l/r right joystick
-                [3] = u/d right joystick
-                [4] = left trigger
-                [5] = right trigger
-
-                Button Activations
-                [0] = x
-                [1] = circle
-                [2] = triangle
-                [3] = square
-                [4] = left bumper
-                [5] = right bumper
-                [6] = left trigger
-                [7] = right trigger
-                [8] = share
-                [9] = options
-                [10] = playstation button
-                [11] = left joystick button
-                [12] = right joystick button
-                [13] = up arrow
-                [14] = down arrow
-                [15] = left arrow
-                [16] = right arrow
-                """
-
-                # Left stick: left and right
-                if(self.axis_data.get(0) < -self.activation):
-                    joystick_vels[0] = ((self.axis_data[0] + self.activation) / (1 - self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                elif(self.axis_data.get(0) > self.activation):
-                    joystick_vels[0] = ((self.axis_data[0] - self.activation) / (1 - self.activation))
-                else:
-                    joystick_vels[0] = 0
-
-                # Left stick: up and down
-                axis_1_multiplier = 1 if self.is_jetson else -1
-                if(self.axis_data.get(1) < -self.activation):
-                    joystick_vels[1] = axis_1_multiplier * ((self.axis_data[1] + self.activation) / (1 -self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                elif(self.axis_data.get(1) >self.activation):
-                    joystick_vels[1] = axis_1_multiplier * ((self.axis_data[1] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[1] = 0
-
-                # Right stick: left and right
-                if(self.axis_data.get(3) < -self.activation):
-                    joystick_vels[2] = ((self.axis_data[3] + self.activation) / (1 -self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                elif(self.axis_data.get(3) >self.activation):
-                    joystick_vels[2] = ((self.axis_data[3] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[2] = 0
-
-                # Right stick: up and down
-                axis_index = 5 if self.is_jetson else 4
-                if(self.axis_data.get(axis_index) < -self.activation):
-                    joystick_vels[3] = -((self.axis_data[axis_index] + self.activation) / (1 -self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                elif(self.axis_data.get(axis_index) > self.activation):
-                    joystick_vels[3] = -((self.axis_data[axis_index] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[3] = 0
-
-                # Left Trigger
-                if(self.axis_data.get(2) > 0):
-                    joystick_vels[4] = self.axis_data[2] 
-                else:
-                    joystick_vels[4] = 0
-
-                # Right Trigger
-                if(self.axis_data.get(5) > 0):
-                    joystick_vels[5] = self.axis_data[5]
-                else:
-                    joystick_vels[5] = 0
-                
-                # Buttons
-                for i in range(13):
-                    button_activations[i] = self.button_data[i]
-
-        elif(self.joystick_type == 1):    
-
-                """
-                Thrustmaster:
-                Joystick Velocities
-                [0] = rotate
-                [1] = forward/backwards 
-                [2] = left/right
-                [3] = slider
-                [4] = empty
-                [5] = empty
-
-                Button Activations
-                [0] = trigger
-                [1] = bottom on stick
-                [2] = left on stick
-                [3] = right on stick
-                [4] = left side - top left
-                [5] = left side - top middle
-                [6] = left side - top right
-                [7] = left side - bottom right
-                [8] = left side - bottom middle
-                [9] = left side - bottom left
-                [10] = right side - top right
-                [11] = right side - top middle
-                [12] = right side - top left
-                [13] = right side - bottom left
-                [14] = right side - bottom middle
-                [15] = right side - bottom right
-                [16] = empty
-                """ 
-                # self.get_logger().info(str(self.joystick_type))
-                # print(self.axis_data.get(2))
-
-                # Rotate 
-
-                joystick_vels[0] = self.axis_data.get(2)
-
-                # if(self.axis_data.get(2) < -self.activation):
-                #     #joystick_vels[0] = ((self.axis_data[0] + self.activation) / (1 - self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                #     joystick_vels[0] = -self.axis_data[0]
-                # elif(self.axis_data.get(2) > self.activation):
-                #     #joystick_vels[0] = ((self.axis_data[0] - self.activation) / (1 - self.activation))
-                #     joystick_vels[0] = self.axis_data[0]
-                
-                # else:
-                #     joystick_vels[0] = 0
-
-                # Up and Down
-                if(self.axis_data.get(1) < -self.activation):
-                    joystick_vels[1] = -((self.axis_data[1] + self.activation) / (1 -self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                elif(self.axis_data.get(1) >self.activation):
-                    joystick_vels[1] = -((self.axis_data[1] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[1] = 0
-
-                # Left/Right
-                if(self.axis_data.get(0) < -self.activation):
-                    joystick_vels[2] = ((self.axis_data[3] + self.activation) / (1 -self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                elif(self.axis_data.get(0) >self.activation):
-                    joystick_vels[2] = ((self.axis_data[3] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[2] = 0
-
-                # Slider
-                if(self.axis_data.get(3) < -self.activation):
-                    joystick_vels[3] = -((self.axis_data[4] + self.activation) / (1 -self.activation))  # normalizes the 0.25 to 1 range to a 0 - 1 range and then mult by max vel
-                elif(self.axis_data.get(3) > self.activation):
-                    joystick_vels[3] = -((self.axis_data[4] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[3] = 0
-                
-                # Buttons
-                for i in range(13):
-                    button_activations[i] = self.button_data[i]
-        elif(self.joystick_type == 2 or self.joystick_type == 3):
-
-                """
-                Xbox One / 8BitDo Ultimate Controller:
-                Joystick Velocities
-                [0] = l/r left joystick
-                [1] = u/d left joystick
-                [2] = l/r right joystick
-                [3] = u/d right joystick
-                [4] = left trigger
-                [5] = right trigger
-
-                Button Activations
-                [0] = A
-                [1] = B
-                [2] = X
-                [3] = Y
-                [4] = left bumper
-                [5] = right bumper
-                [6] = TV
-                [7] = Menu
-                [8] = left joystick button
-                [9] = right joystick button
-                """
-
-                # Left stick: left and right
-                if(self.axis_data.get(0) < -self.activation):
-                    joystick_vels[0] = ((self.axis_data[0] + self.activation) / (1 - self.activation))
-                elif(self.axis_data.get(0) > self.activation):
-                    joystick_vels[0] = ((self.axis_data[0] - self.activation) / (1 - self.activation))
-                else:
-                    joystick_vels[0] = 0
-
-                # Left stick: up and down
-                axis_1_multiplier = 1 if self.is_jetson else -1
-                if(self.axis_data.get(1) < -self.activation):
-                    joystick_vels[1] = axis_1_multiplier * ((self.axis_data[1] + self.activation) / (1 -self.activation))
-                elif(self.axis_data.get(1) >self.activation):
-                    joystick_vels[1] = axis_1_multiplier * ((self.axis_data[1] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[1] = 0
-
-                # Right stick: left and right
-                if(self.axis_data.get(3) < -self.activation):
-                    joystick_vels[2] = ((self.axis_data[3] + self.activation) / (1 -self.activation))
-                elif(self.axis_data.get(3) >self.activation):
-                    joystick_vels[2] = ((self.axis_data[3] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[2] = 0
-
-                # Right stick: up and down
-                axis_index = 5 if self.is_jetson else 4
-                if(self.axis_data.get(axis_index) < -self.activation):
-                    joystick_vels[3] = -((self.axis_data[axis_index] + self.activation) / (1 -self.activation))
-                elif(self.axis_data.get(axis_index) > self.activation):
-                    joystick_vels[3] = -((self.axis_data[axis_index] - self.activation) / (1 -self.activation)) 
-                else:
-                    joystick_vels[3] = 0
-
-                # Left Trigger
-                if(self.axis_data.get(2) > 0):
-                    joystick_vels[4] = self.axis_data[2] 
-                else:
-                    joystick_vels[4] = 0
-
-                # Right Trigger
-                if(self.axis_data.get(5) > 0):
-                    joystick_vels[5] = self.axis_data[5]
-                else:
-                    joystick_vels[5] = 0
-                
-                # Buttons
-                for i in range(min(10, len(button_activations))):
-                    button_activations[i] = self.button_data.get(i, False)
-        else:
-            print('calibrate:', pprint.pprint(self.axis_data))
+            # Buttons
+            for i in range(13):
+                button_activations[i] = self.button_data[i]
 
         # Save current numpy array for joystick and buttons
         self.previous_axes = joystick_vels

--- a/src/teleop/teleop/teleop/joystick_publisher.py
+++ b/src/teleop/teleop/teleop/joystick_publisher.py
@@ -67,10 +67,10 @@ class JoystickPublisher(Node):
         self.button_data = None
         self.hat_data = None
         self.activation = 0.08
-        JOYSTICK_NAMES = {
+        JOYSTICK_NAMES = {s
             "thrustmaster": "thrustmaster t.16000m",
-            "xbox": "xbox series x controller",
-            "aibus": "t.a320 pilot"
+            "xbox": "xbox 360 controller",
+            "airbus": "thrustmaster t.a320 copilot"
         }
         target_name = JOYSTICK_NAMES[self.joystick_type]
 
@@ -127,14 +127,14 @@ class JoystickPublisher(Node):
         self.previous_axes = np.zeros(len(self._slot_params))
         self.previous_buttons = np.zeros(len(self.button_data))
 
-    def _normalize(self, raw, invert, trigger):
+    def _normalize(self, raw, invert, trigger, range_inverted=False):
         if abs(raw) < self.activation:
             val = 0.0
         else:
             val = (abs(raw) - self.activation) / (1.0 - self.activation)
             val = val if raw > 0 else -val
         if trigger:
-            val = (val + 1.0) / 2.0
+            val = (1.0 - val) / 2.0 if range_inverted else (val + 1.0) / 2.0
         if invert:
             val = -val
         return val
@@ -159,7 +159,8 @@ class JoystickPublisher(Node):
                 joystick_vels[i] = self._normalize(
                     self.axis_data.get(slot['axis'], 0.0),
                     slot['invert'],
-                    slot['trigger']
+                    slot['trigger'],
+                    slot.get('range_inverted', False)
                 )
 
             # Buttons

--- a/src/teleop/teleop/teleop/joystick_publisher.py
+++ b/src/teleop/teleop/teleop/joystick_publisher.py
@@ -70,6 +70,7 @@ class JoystickPublisher(Node):
         JOYSTICK_NAMES = {
             "thrustmaster": "thrustmaster t.16000m",
             "xbox": "xbox series x controller",
+            "aibus": "t.a320 pilot"
         }
         target_name = JOYSTICK_NAMES[self.joystick_type]
 

--- a/src/teleop/teleop/teleop/joystick_publisher.py
+++ b/src/teleop/teleop/teleop/joystick_publisher.py
@@ -42,10 +42,10 @@ class JoystickPublisher(Node):
             config = yaml.safe_load(f)
 
 
-        axes_list = config['ros__parameters']['controllers'][self.joystick_type]['axes']
+        axes_list = config['/**']['ros__parameters']['controllers'][self.joystick_type]['axes']
 
         self._axes_config = {e['name']: e for e in axes_list}
-        slots = config['ros__parameters']['subsystems'][self.subsystem]['output_slots']
+        slots = config['/**']['ros__parameters']['subsystems'][self.subsystem]['output_slots']
         self._slot_params = [self._axes_config[name] for name in slots]
 
         
@@ -67,18 +67,24 @@ class JoystickPublisher(Node):
         self.button_data = None
         self.hat_data = None
         self.activation = 0.08
+        JOYSTICK_NAMES = {
+            "thrustmaster": "thrustmaster t.16000m",
+            "xbox": "xbox series x controller",
+        }
+        target_name = JOYSTICK_NAMES[self.joystick_type]
+
         self.joystick_index = None
 
         # Pygame Controller
         pygame.init()
-        pygame.joystick.init()            
+        pygame.joystick.init()
         joysticks = pygame.joystick.get_count()
         self.get_logger().info(f"Number of joysticks found: {joysticks}")
 
         for i in range(joysticks):
             js = pygame.joystick.Joystick(i)
             name = js.get_name().lower()
-            if(name == self.joystick_type):
+            if(name == target_name):
                 self.joystick_index = i
                 break
 
@@ -118,7 +124,7 @@ class JoystickPublisher(Node):
                 self.hat_data[i] = (0, 0)
 
         self.previous_axes = np.zeros(len(self._slot_params))
-        self.previous_buttons = np.zeros(13)        
+        self.previous_buttons = np.zeros(len(self.button_data))
 
     def _normalize(self, raw, invert, trigger):
         if abs(raw) < self.activation:
@@ -156,7 +162,7 @@ class JoystickPublisher(Node):
                 )
 
             # Buttons
-            for i in range(13):
+            for i in self.button_data:
                 button_activations[i] = self.button_data[i]
 
         # Save current numpy array for joystick and buttons


### PR DESCRIPTION
- Replaced hardcoded PS4/Thrustmaster logic in joystick_publisher.py w/ axes normalization driven by a central joy.yaml config file. The publisher now reads controller axis definitions and subsystem slot mappings from YAML, publishes to controller_input/{joystick_type}, and selects a device by name via a JOYSTICK_NAMES dict.
- Added the TCA Sidestick Airbus as the controller for the arm, and Xbox controller for science.
- Each controller_input topic has a different topic for each controller (e.g. "controller_input/xbox", "controller_input/airbus").
- Changed joystick type params for all subsytems to be strings and not integers (0/1 -> "xbox", "airbus").
- Each subsystem's launch file reads joystick_type from their joystick.yaml at launch time
- Added documentation in the joy.yaml file so its clear what each axes/button does what.