### PR TITLE
Centralize CAN Interface

### DIFF
--- a/src/bringup/launch/autonav.launch.py
+++ b/src/bringup/launch/autonav.launch.py
@@ -99,6 +99,11 @@ def generate_launch_description():
             choices=['true', 'false'],
             description='Launch the Nav2 config GUI.',
         ),
+        DeclareLaunchArgument(
+            'can_interface',
+            default_value='can1',
+            description='CAN interface to use for hardware interfaces.',
+        ),
         OpaqueFunction(function=launch_setup),
     ])
 
@@ -116,6 +121,7 @@ def launch_setup(context, *args, **kwargs):
     use_respawn = LaunchConfiguration('use_respawn').perform(context)
     log_level = LaunchConfiguration('log_level').perform(context)
     use_config = LaunchConfiguration('use_config').perform(context)
+    can_interface = LaunchConfiguration('can_interface').perform(context)
 
     drive_bringup = get_package_share_directory('drive_bringup')
     nav_bringup = get_package_share_directory('nav_bringup')
@@ -131,6 +137,7 @@ def launch_setup(context, *args, **kwargs):
             'use_mock_hardware': use_mock_hardware,
             'mock_sensor_commands': mock_sensor_commands,
             'robot_controller': robot_controller,
+            'can_interface': can_interface,
         }.items(),
     )
 
@@ -147,6 +154,7 @@ def launch_setup(context, *args, **kwargs):
             'use_respawn': use_respawn,
             'log_level': log_level,
             'use_config': use_config,
+            'can_interface': can_interface,
         }.items(),
     )
 

--- a/src/bringup/launch/delivery.launch.py
+++ b/src/bringup/launch/delivery.launch.py
@@ -43,6 +43,7 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument('use_3dof', default_value='false', choices=['true', 'false']),
         DeclareLaunchArgument('deactivate_talon', default_value='false', choices=['true', 'false']),
+        DeclareLaunchArgument('can_interface', default_value='can1'),
         OpaqueFunction(function=launch_setup),
     ])
 
@@ -55,6 +56,7 @@ def launch_setup(context, *args, **kwargs):
     robot_controller = LaunchConfiguration('robot_controller').perform(context)
     use_3dof = LaunchConfiguration('use_3dof').perform(context)
     deactivate_talon = LaunchConfiguration('deactivate_talon').perform(context)
+    can_interface = LaunchConfiguration('can_interface').perform(context)
 
     drive_share = get_package_share_directory('drive_bringup')
     arm_bringup_share = get_package_share_directory('arm_bringup')
@@ -73,6 +75,7 @@ def launch_setup(context, *args, **kwargs):
             'use_mock_hardware': use_mock_hardware,
             'mock_sensor_commands': mock_sensor_commands,
             'robot_controller': robot_controller,
+            'can_interface': can_interface,
         }.items(),
     )
 
@@ -103,6 +106,7 @@ def launch_setup(context, *args, **kwargs):
         ' mock_sensor_commands:=', mock_sensor_commands,
         ' use_3dof:=', use_3dof,
         ' deactivate_talon:=', deactivate_talon, ' ',
+        ' can_interface:=', can_interface, ' ',
     ])
 
     use_3dof_bool = use_3dof.lower() == 'true'

--- a/src/bringup/launch/equipment_servicing.launch.py
+++ b/src/bringup/launch/equipment_servicing.launch.py
@@ -43,6 +43,7 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument('use_3dof', default_value='false', choices=['true', 'false']),
         DeclareLaunchArgument('deactivate_talon', default_value='false', choices=['true', 'false']),
+        DeclareLaunchArgument('can_interface', default_value='can1'),
         OpaqueFunction(function=launch_setup),
     ])
 
@@ -55,6 +56,7 @@ def launch_setup(context, *args, **kwargs):
     robot_controller = LaunchConfiguration('robot_controller').perform(context)
     use_3dof = LaunchConfiguration('use_3dof').perform(context)
     deactivate_talon = LaunchConfiguration('deactivate_talon').perform(context)
+    can_interface = LaunchConfiguration('can_interface').perform(context)
 
     drive_share = get_package_share_directory('drive_bringup')
     arm_bringup_share = get_package_share_directory('arm_bringup')
@@ -73,6 +75,7 @@ def launch_setup(context, *args, **kwargs):
             'use_mock_hardware': use_mock_hardware,
             'mock_sensor_commands': mock_sensor_commands,
             'robot_controller': robot_controller,
+            'can_interface': can_interface,
         }.items(),
     )
 
@@ -103,6 +106,7 @@ def launch_setup(context, *args, **kwargs):
         ' mock_sensor_commands:=', mock_sensor_commands,
         ' use_3dof:=', use_3dof,
         ' deactivate_talon:=', deactivate_talon, ' ',
+        ' can_interface:=', can_interface, ' ',        
     ])
 
     use_3dof_bool = use_3dof.lower() == 'true'

--- a/src/description/config/odrive.ros2_control.xacro
+++ b/src/description/config/odrive.ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="odrive_ros2_control" params="name">
+  <xacro:macro name="odrive_ros2_control" params="name can_interface:=can0">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>odrive_ros2_control_plugin/ODriveHardwareInterface</plugin>
-        <param name="can">can0</param>
+        <param name="can">${can_interface}</param>
       </hardware>
 
        <!-- 

--- a/src/description/launch/display.launch.py
+++ b/src/description/launch/display.launch.py
@@ -10,6 +10,12 @@ import os
 
 def generate_launch_description():
     model_arg = DeclareLaunchArgument('model', default_value='', description='Model argument')
+    can_interface_arg = DeclareLaunchArgument(
+        'can_interface',
+        default_value='can0',
+        description='CAN interface to use for hardware interfaces.',
+    )
+    can_interface = LaunchConfiguration('can_interface')
 
     # Get URDF path
     robot_description_path = PathJoinSubstitution([
@@ -25,6 +31,8 @@ def generate_launch_description():
             " ",
             robot_description_path,
             " use_mock_hardware:=true",
+            " can_interface:=",
+            can_interface,
         ]
     )
 
@@ -120,6 +128,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         model_arg,
+        can_interface_arg,
         robot_state_publisher_node,
         ros2_control_node,
         joint_state_broadcaster_spawner,

--- a/src/description/ros2_control/arm/arm.base_limit_switch.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.base_limit_switch.ros2_control.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="base_arm_limit_switch_ros2_control" params="name">
+  <xacro:macro name="base_arm_limit_switch_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>limit_switch_ros2_control/LimitSwitchHardwareInterface</plugin>
-        <param name="can_interface">can1</param>
+        <param name="can_interface">${can_interface}</param>
         <param name="can_id">0x130</param>
         <param name="update_rate">10</param>
         <param name="logger_rate">5</param>

--- a/src/description/ros2_control/arm/arm.end_effector_limit_switch.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.end_effector_limit_switch.ros2_control.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="end_effector_limit_switch_ros2_control" params="name">
+  <xacro:macro name="end_effector_limit_switch_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>limit_switch_ros2_control/LimitSwitchHardwareInterface</plugin>
-        <param name="can_interface">can1</param>
+        <param name="can_interface">${can_interface}</param>
         <param name="can_id">0x60</param>
         <param name="update_rate">10</param>
         <param name="logger_rate">5</param>

--- a/src/description/ros2_control/arm/arm.rmd.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.rmd.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="rmd_ros2_control" params="name">
+  <xacro:macro name="rmd_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>rmd_ros2_control/RMDHardwareInterface</plugin>
         <param name="update_rate">10</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can1</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="shoulder_pitch">

--- a/src/description/ros2_control/arm/arm.rotary_encoder.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.rotary_encoder.ros2_control.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="rotary_encoder_ros2_control" params="name">
+  <xacro:macro name="rotary_encoder_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>rotary_encoder_ros2_control/RotaryEncoderHardwareInterface</plugin>
-        <param name="can_interface">can1</param>
+        <param name="can_interface">${can_interface}</param>
         <param name="can_id">0x130</param>
         <param name="update_rate">10</param>
         <param name="logger_rate">5</param>

--- a/src/description/ros2_control/arm/arm.servo.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.servo.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="servo_ros2_control" params="name">
+    <xacro:macro name="servo_ros2_control" params="name can_interface:=can0">
         <ros2_control name="${name}" type="system">
             <hardware>
                 <plugin>servo_ros2_control/SERVOHardwareInterface</plugin>
                 <param name="update_rate">1</param> <!-- Hz -->
                 <param name="logger_rate">5</param> <!-- Hz -->
                 <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-                <param name="can_interface">can1</param>
+                <param name="can_interface">${can_interface}</param>
                 <param name="can_id">0x80</param>
             </hardware>
 

--- a/src/description/ros2_control/arm/arm.smc_2dof.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.smc_2dof.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="smc_2dof_ros2_control" params="name">
+  <xacro:macro name="smc_2dof_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>smc_ros2_control/SMCHardwareInterface</plugin>
         <param name="update_rate">10</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can1</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="base_yaw">

--- a/src/description/ros2_control/arm/arm.smc_3dof.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.smc_3dof.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="smc_3dof_ros2_control" params="name">
+  <xacro:macro name="smc_3dof_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>smc_ros2_control/SMCHardwareInterface</plugin>
         <param name="update_rate">10</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can1</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="base_yaw">

--- a/src/description/ros2_control/arm/arm.talon_2dof.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.talon_2dof.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="talon_2dof_ros2_control" params="name deactivate_talon">
+  <xacro:macro name="talon_2dof_ros2_control" params="name deactivate_talon can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <param name="deactivate_talon">${deactivate_talon}</param>
@@ -12,7 +12,7 @@
           <param name="update_rate">10</param> <!-- Hz -->
           <param name="logger_rate">5</param> <!-- Hz -->
           <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-          <param name="can_interface">can1</param>
+          <param name="can_interface">${can_interface}</param>
         </xacro:unless>
       </hardware>
 

--- a/src/description/ros2_control/arm/arm.talon_3dof.ros2_control.xacro
+++ b/src/description/ros2_control/arm/arm.talon_3dof.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="talon_3dof_ros2_control" params="name deactivate_talon">
+  <xacro:macro name="talon_3dof_ros2_control" params="name deactivate_talon can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${deactivate_talon}">
@@ -11,7 +11,7 @@
           <param name="update_rate">10</param> <!-- Hz -->
           <param name="logger_rate">5</param> <!-- Hz -->
           <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-          <param name="can_interface">can1</param>
+          <param name="can_interface">${can_interface}</param>
         </xacro:unless>
       </hardware>
 

--- a/src/description/ros2_control/drive/drive.led.ros2_control.xacro
+++ b/src/description/ros2_control/drive/drive.led.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="led_ros2_control" params="name can_interface">
+  <xacro:macro name="led_ros2_control" params="name can_interface:=can0">
 
     <ros2_control name="${name}" type="system">
       <hardware>

--- a/src/description/ros2_control/drive/drive.odrive.ros2_control.xacro
+++ b/src/description/ros2_control/drive/drive.odrive.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="odrive_ros2_control" params="name deactivate_odrive">
+  <xacro:macro name="odrive_ros2_control" params="name deactivate_odrive can_interface:=can0">
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -14,7 +14,7 @@
           <param name="update_rate">30</param> <!-- Hz -->
           <param name="logger_rate">5</param> <!-- Hz -->
           <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-          <param name="can">can1</param>
+          <param name="can">${can_interface}</param>
         </xacro:unless>
       </hardware>
 

--- a/src/description/ros2_control/drive/drive.rmd.ros2_control.xacro
+++ b/src/description/ros2_control/drive/drive.rmd.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="rmd_ros2_control" params="name">
+  <xacro:macro name="rmd_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>rmd_ros2_control/RMDHardwareInterface</plugin>
         <param name="update_rate">30</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can1</param>
+        <param name="can_interface">${can_interface}</param>
       </hardware>
 
       <joint name="propulsion_fl_joint">

--- a/src/description/ros2_control/science/science.dc.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.dc.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="dc_ros2_control" params="name">
+  <xacro:macro name="dc_ros2_control" params="name can_interface:=can0">
 
     <ros2_control name="${name}" type="system">
 
@@ -10,7 +10,7 @@
         <param name="update_rate">20</param> <!-- Hz -->
         <param name="logger_rate">5</param> <!-- Hz -->
         <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
         <param name="can_id">0x70</param>
       </hardware>
 

--- a/src/description/ros2_control/science/science.led.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.led.ros2_control.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="science_led_ros2_control" params="name">
+  <xacro:macro name="science_led_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>led_ros2_control/LEDHardwareInterface</plugin>
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
         <param name="can_id">0x110</param>
         <param name="update_rate">10</param>
         <param name="logger_rate">5</param>

--- a/src/description/ros2_control/science/science.limit_switch.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.limit_switch.ros2_control.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="science_limit_switch_ros2_control" params="name">
+  <xacro:macro name="science_limit_switch_ros2_control" params="name can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>limit_switch_ros2_control/LimitSwitchHardwareInterface</plugin>
-        <param name="can_interface">can0</param>
+        <param name="can_interface">${can_interface}</param>
         <param name="can_id">0x100</param>
         <param name="update_rate">10</param>
         <param name="logger_rate">5</param>

--- a/src/description/ros2_control/science/science.servo.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.servo.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="servo_ros2_control" params="name">
+    <xacro:macro name="servo_ros2_control" params="name can_interface:=can0">
         <ros2_control name="${name}" type="system">
             <hardware>
                 <plugin>servo_ros2_control/SERVOHardwareInterface</plugin>
                 <param name="update_rate">20</param> <!-- Hz -->
                 <param name="logger_rate">5</param> <!-- Hz -->
                 <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-                <param name="can_interface">can0</param>
+                <param name="can_interface">${can_interface}</param>
                 <param name="can_id">0x80</param>
             </hardware>
 

--- a/src/description/ros2_control/science/science.stepper.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.stepper.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="stepper_ros2_control" params="name">
+    <xacro:macro name="stepper_ros2_control" params="name can_interface:=can0">
 
         <ros2_control name="${name}" type="system">
 
@@ -10,7 +10,7 @@
                 <param name="update_rate">10</param> <!-- Hz -->
                 <param name="logger_rate">5</param> <!-- Hz -->
                 <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-                <param name="can_interface">can0</param>
+                <param name="can_interface">${can_interface}</param>
                 <param name="can_id">0x90</param>
             </hardware>
 

--- a/src/description/ros2_control/science/science.talon.ros2_control.xacro
+++ b/src/description/ros2_control/science/science.talon.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="talon_ros2_control" params="name deactivate_talon">
+  <xacro:macro name="talon_ros2_control" params="name deactivate_talon can_interface:=can0">
     <ros2_control name="${name}" type="system">
       <hardware>
         <param name="deactivate_talon">${deactivate_talon}</param>
@@ -12,7 +12,7 @@
           <param name="update_rate">10</param> <!-- Hz -->
           <param name="logger_rate">5</param> <!-- Hz -->
           <param name="logger_state">0</param> <!-- 0 for off, 1 for on -->
-          <param name="can_interface">can0</param>
+          <param name="can_interface">${can_interface}</param>
         </xacro:unless>
       </hardware>
 

--- a/src/description/urdf/athena_arm.urdf.xacro
+++ b/src/description/urdf/athena_arm.urdf.xacro
@@ -10,6 +10,7 @@
   <xacro:arg name="simulation_controllers" default=""/>
   <xacro:arg name="use_3dof" default="false"/>
   <xacro:arg name="deactivate_talon" default="false"/>
+  <xacro:arg name="can_interface" default="can0"/>
 
   <!-- Macro Imports -->
   <!-- Import athena_arm macro -->
@@ -56,20 +57,20 @@
   </xacro:if>
   <xacro:unless value="$(arg use_mock_hardware)"> <!-- HARDWARE -->
     <xacro:if value="$(arg use_3dof)">
-      <xacro:talon_3dof_ros2_control name="talon" deactivate_talon="$(arg deactivate_talon)"/>
-      <xacro:smc_3dof_ros2_control name="smc"/> 
+      <xacro:talon_3dof_ros2_control name="talon" deactivate_talon="$(arg deactivate_talon)" can_interface="$(arg can_interface)"/>
+      <xacro:smc_3dof_ros2_control name="smc" can_interface="$(arg can_interface)"/> 
     </xacro:if>
     <xacro:unless value="$(arg use_3dof)">
-      <xacro:talon_2dof_ros2_control name="talon" deactivate_talon="$(arg deactivate_talon)"/>
-      <xacro:smc_2dof_ros2_control name="smc"/> 
+      <xacro:talon_2dof_ros2_control name="talon" deactivate_talon="$(arg deactivate_talon)" can_interface="$(arg can_interface)"/>
+      <xacro:smc_2dof_ros2_control name="smc" can_interface="$(arg can_interface)"/> 
     </xacro:unless>
 
-    <xacro:rmd_ros2_control name="rmd"/>
-    <xacro:servo_ros2_control name="servo"/>
-    <xacro:rotary_encoder_ros2_control name="rotary_encoder"/>
-    <xacro:base_arm_limit_switch_ros2_control name="base_arm_limit_switch"/>
-    <xacro:end_effector_limit_switch_ros2_control name="end_effector_limit_switch"/>
-    <!-- <xacro:odrive_ros2_control name="odrive"/> -->
+    <xacro:rmd_ros2_control name="rmd" can_interface="$(arg can_interface)"/>
+    <xacro:servo_ros2_control name="servo" can_interface="$(arg can_interface)"/>
+    <xacro:rotary_encoder_ros2_control name="rotary_encoder" can_interface="$(arg can_interface)"/>
+    <xacro:base_arm_limit_switch_ros2_control name="base_arm_limit_switch" can_interface="$(arg can_interface)"/>
+    <xacro:end_effector_limit_switch_ros2_control name="end_effector_limit_switch" can_interface="$(arg can_interface)"/>
+    <!-- <xacro:odrive_ros2_control name="odrive" can_interface="$(arg can_interface)"/> -->
   </xacro:unless>
 
 </robot>

--- a/src/description/urdf/athena_drive.urdf.xacro
+++ b/src/description/urdf/athena_drive.urdf.xacro
@@ -8,6 +8,7 @@
   <xacro:arg name="sim_gazebo" default="true"/>
   <xacro:arg name="simulation_controllers" default=""/>
   <xacro:arg name="deactivate_odrive" default="false"/>
+  <xacro:arg name="can_interface" default="can0"/>
 
 
   <xacro:include filename="$(find description)/urdf/athena_drive/athena_drive_macro.xacro"/>
@@ -72,16 +73,16 @@
   <xacro:unless value="$(arg use_mock_hardware)">
 
     <!-- ODrives-->
-    <xacro:odrive_ros2_control name="odrive" deactivate_odrive="$(arg deactivate_odrive)"/>
+    <xacro:odrive_ros2_control name="odrive" deactivate_odrive="$(arg deactivate_odrive)" can_interface="$(arg can_interface)"/>
 
     <!-- RMD -->
-    <xacro:rmd_ros2_control name="rmd"/>
+    <xacro:rmd_ros2_control name="rmd" can_interface="$(arg can_interface)"/>
 
     <!-- LED status indicator (GPIO-based) -->
-    <xacro:led_ros2_control name="drive_led" can_interface="can0"/>
+    <xacro:led_ros2_control name="drive_led" can_interface="$(arg can_interface)"/>
 
     <!-- PowerModule (CAN-based) -->
-    <xacro:power_module_ros2_control name="drive_power_module" can_interface="can0"/>
+    <xacro:power_module_ros2_control name="drive_power_module" can_interface="$(arg can_interface)"/>
   </xacro:unless>
 
   

--- a/src/description/urdf/athena_science.urdf.xacro
+++ b/src/description/urdf/athena_science.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:arg name="use_mock_hardware" default="false"/>
   <xacro:arg name="mock_sensor_commands" default="false"/>
   <xacro:arg name="deactivate_talon" default="false"/>
+  <xacro:arg name="can_interface" default="can0"/>
 
   <xacro:include filename="$(find description)/ros2_control/science/science.mock.ros2_control.xacro"/>
 
@@ -29,23 +30,23 @@
   <xacro:unless value="$(arg use_mock_hardware)">
 
     <!-- Import stepper ros2_control description -->
-    <xacro:stepper_ros2_control name="stepper"/>
+    <xacro:stepper_ros2_control name="stepper" can_interface="$(arg can_interface)"/>
 
     <!-- Import servo ros2_control description -->
-    <xacro:servo_ros2_control name="servo"/>
+    <xacro:servo_ros2_control name="servo" can_interface="$(arg can_interface)"/>
 
     <!-- Import dc ros2_control description -->
-    <xacro:dc_ros2_control name="dc"/>
+    <xacro:dc_ros2_control name="dc" can_interface="$(arg can_interface)"/>
 
     <!-- Import talon ros2_control description -->
-    <!-- <xacro:talon_ros2_control name="talon" deactivate_talon="$(arg deactivate_talon)"/> -->
+    <!-- <xacro:talon_ros2_control name="talon" deactivate_talon="$(arg deactivate_talon)" can_interface="$(arg can_interface)"/> -->
 
     <!-- Import laser ros2_control description (CAN-based) -->
-    <xacro:laser_ros2_control name="spectrometry_laser"/>
+    <xacro:laser_ros2_control name="spectrometry_laser" can_interface="$(arg can_interface)"/>
 
     <!-- Import LED and limit switch ros2_control descriptions -->
-    <xacro:science_led_ros2_control name="fluoro_led_hwi"/>
-    <xacro:science_limit_switch_ros2_control name="science_limit_switch_hwi"/>
+    <xacro:science_led_ros2_control name="fluoro_led_hwi" can_interface="$(arg can_interface)"/>
+    <xacro:science_limit_switch_ros2_control name="science_limit_switch_hwi" can_interface="$(arg can_interface)"/>
   </xacro:unless>
 
 </robot>

--- a/src/simulation/launch/spawn.launch.py
+++ b/src/simulation/launch/spawn.launch.py
@@ -22,6 +22,8 @@ ARGUMENTS = [
                           description='Robot namespace'),
     DeclareLaunchArgument('world_name', default_value='',
                           description='World name'),
+    DeclareLaunchArgument('can_interface', default_value='can0',
+                          description='CAN interface to use for hardware interfaces.'),
     
 ]
 
@@ -34,13 +36,16 @@ def generate_launch_description():
     rviz_config_file = os.path.join(pkg_sim, 'rviz', 'sim.rviz')
     
     namespace = LaunchConfiguration('namespace')
+    can_interface = LaunchConfiguration('can_interface')
     robot_name = 'athena'
 
     robot_description_content = Command([
         'xacro ', urdf_file,
         ' use_mock_hardware:=true',
         ' sim_gazebo:=true',
-        f' simulation_controllers:={controllers_file}'
+        f' simulation_controllers:={controllers_file}',
+        ' can_interface:=',
+        can_interface,
     ])
 
     spawn_robot_group_action = GroupAction([

--- a/src/subsystems/arm/arm_bringup/launch/athena_arm.jetson.launch.py
+++ b/src/subsystems/arm/arm_bringup/launch/athena_arm.jetson.launch.py
@@ -71,6 +71,13 @@ def generate_launch_description():
             description="Deactivate the talon joints in the URDF when using mock hardware to prevent excessive CAN flow.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "can_interface",
+            default_value="can0",
+            description="CAN interface to use for hardware interfaces.",
+        )
+    )
     # -- Initialize Arguments --
     runtime_config_package = LaunchConfiguration("runtime_config_package")
     controllers_file = LaunchConfiguration("controllers_file")
@@ -80,6 +87,7 @@ def generate_launch_description():
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     use_3dof = LaunchConfiguration("use_3dof")
     deactivate_talon = LaunchConfiguration("deactivate_talon")
+    can_interface = LaunchConfiguration("can_interface")
     
     # -- Building Path Files --
     robot_description_path = PathJoinSubstitution(
@@ -114,6 +122,9 @@ def generate_launch_description():
             " ",
             "deactivate_talon:=",
             deactivate_talon,
+            " ",
+            "can_interface:=",
+            can_interface,
             " ",
         ]
     )

--- a/src/subsystems/arm/arm_bringup/launch/athena_arm.jetson.launch.py
+++ b/src/subsystems/arm/arm_bringup/launch/athena_arm.jetson.launch.py
@@ -74,7 +74,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "can_interface",
-            default_value="can0",
+            default_value="can1",
             description="CAN interface to use for hardware interfaces.",
         )
     )

--- a/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
+++ b/src/subsystems/arm/arm_bringup/launch/athena_arm.launch.py
@@ -115,6 +115,13 @@ def generate_launch_description():
             description="Deactivate the talon joints in the URDF when using mock hardware to prevent excessive CAN flow.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "can_interface",
+            default_value="can0",
+            description="CAN interface to use for hardware interfaces.",
+        )
+    )
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])
 
@@ -133,6 +140,7 @@ def launch_setup(context, *args, **kwargs):
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     use_3dof = LaunchConfiguration("use_3dof")
     deactivate_talon = LaunchConfiguration("deactivate_talon")
+    can_interface = LaunchConfiguration("can_interface")
     
     # -- Building Path Files --
     # Get URDF via xacro.
@@ -191,6 +199,9 @@ def launch_setup(context, *args, **kwargs):
             " ",
             "deactivate_talon:=",
             deactivate_talon,
+            " ",
+            "can_interface:=",
+            can_interface,
         ]
     )
     robot_description = {"robot_description": robot_description_content}

--- a/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
+++ b/src/subsystems/drive/drive_bringup/launch/athena_drive.launch.py
@@ -119,6 +119,13 @@ def generate_launch_description():
             description="Deactivate the ODrive joints in the URDF when using mock hardware to prevent excessive CAN flow.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "can_interface",
+            default_value="can0",
+            description="CAN interface to use for hardware interfaces.",
+        )
+    )
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])
 
@@ -138,6 +145,7 @@ def launch_setup(context, *args, **kwargs):
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
     deactivate_odrive = LaunchConfiguration("deactivate_odrive")
+    can_interface = LaunchConfiguration("can_interface")
 
     robot_description_path = PathJoinSubstitution(
         [FindPackageShare(description_package), "urdf", description_file]
@@ -177,6 +185,9 @@ def launch_setup(context, *args, **kwargs):
             " ",
             "deactivate_odrive:=",
             deactivate_odrive,
+            " ",
+            "can_interface:=",
+            can_interface,
         ]
     )
 

--- a/src/subsystems/navigation/nav_bringup/launch/nav_bringup.launch.py
+++ b/src/subsystems/navigation/nav_bringup/launch/nav_bringup.launch.py
@@ -25,6 +25,7 @@ def generate_launch_description():
     use_respawn       = LaunchConfiguration('use_respawn')
     log_level         = LaunchConfiguration('log_level')
     use_config        = LaunchConfiguration('use_config')
+    can_interface     = LaunchConfiguration('can_interface')
 
     use_localizer = PythonExpression(
         ["'false' if '", use_zed_localizer, "' == 'true' else 'true'"]
@@ -38,6 +39,9 @@ def generate_launch_description():
         PathJoinSubstitution([
             FindPackageShare('description'), 'urdf', 'athena_drive.urdf.xacro'
         ]),
+        ' ',
+        'can_interface:=',
+        can_interface,
     ])
 
     robot_state_publisher = Node(
@@ -132,6 +136,11 @@ def generate_launch_description():
             default_value='false',
             choices=['true', 'false'],
             description='Launch the Nav2 config GUI',
+        ),
+        DeclareLaunchArgument(
+            'can_interface',
+            default_value='can0',
+            description='CAN interface to use for hardware interfaces.',
         ),
     
         robot_state_publisher,

--- a/src/subsystems/science/science_bringup/launch/athena_science.launch.py
+++ b/src/subsystems/science/science_bringup/launch/athena_science.launch.py
@@ -100,6 +100,13 @@ def generate_launch_description():
             description="Robot controller to start.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "can_interface",
+            default_value="can0",
+            description="CAN interface to use for hardware interfaces.",
+        )
+    )
 
     # Initialize Arguments
     runtime_config_package = LaunchConfiguration("runtime_config_package")
@@ -111,6 +118,7 @@ def generate_launch_description():
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
     deactivate_talon = LaunchConfiguration("deactivate_talon")
+    can_interface = LaunchConfiguration("can_interface")
 
     # Get URDF via xacro
     robot_description_content = Command(
@@ -132,6 +140,9 @@ def generate_launch_description():
             " ",
             "deactivate_talon:=",
             deactivate_talon,
+            " ",
+            "can_interface:=",
+            can_interface,
         ]
     )
 

--- a/src/tools/scripts/virtual_can_setup.sh
+++ b/src/tools/scripts/virtual_can_setup.sh
@@ -1,2 +1,2 @@
-sudo ip link add dev can0 type vcan
-sudo ip link set up can0
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0


### PR DESCRIPTION
Can interface can now be modified from a simple launch argument.
For example:
`ros2 launch arm_bringup athena_arm.launch.py can_interface:=can1`